### PR TITLE
Verify migration

### DIFF
--- a/provider/app.py
+++ b/provider/app.py
@@ -27,7 +27,7 @@ from service import Service
 app = Flask(__name__)
 app.debug = False
 
-database = Database()
+database = None
 consumers = ConsumerCollection()
 
 
@@ -71,6 +71,8 @@ def main():
     enable_generic_kafka = (generic_kafka == 'True')
     logging.info('enable_generic_kafka is {} {}'.format(enable_generic_kafka, type(enable_generic_kafka)))
 
+    global database
+    database = Database()
     database.migrate()
 
     TheDoctor(consumers).start()

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/tools/verifyDBMigration/index.js
+++ b/tools/verifyDBMigration/index.js
@@ -1,0 +1,130 @@
+var shell = require('shelljs');
+
+// will be populated by processArgs()
+var cloudant,
+    cloudant_user,
+    cloudant_pass,
+    db_name;
+
+function processArgs() {
+    if(process.argv.length != 5) {
+        console.log('USAGE: node index.js CLOUDANT_USER CLOUDANT_PASS DB_NAME');
+        process.exit(1);
+    } else {
+        cloudant_user = process.argv[2];
+        cloudant_pass = process.argv[3];
+        db_name = process.argv[4];
+
+        const Cloudant = require('cloudant');
+        cloudant = Cloudant({
+            url: `https://${cloudant_user}:${cloudant_pass}@${cloudant_user}.cloudant.com`,
+            plugin: 'promises'
+        });
+    }
+}
+
+function verifyDBMigration() {
+    return verifyDBCreatedWithDesignDoc("container0", false)
+        .then(() => {
+            return verifyDBCreatedWithDesignDoc("container1", true);
+        })
+        .catch(err => console.error(`Failed to validate migration: ${JSON.stringify(err)}`));
+}
+
+function verifyDBCreatedWithDesignDoc(containerName, letContainerCreateDB) {
+    return destroyDBIfNeeded()
+        .then(() => {
+            if(!letContainerCreateDB) {
+                console.log(`Creating DB`);
+                return cloudant.db.create(db_name)
+            } else {
+                console.log(`Letting the container create the DB`);
+            }
+        })
+        .then(() => {
+            console.log(`Firing up the docker container`);
+            return startDockerContainer(containerName)
+        })
+        .then(() => {
+            return verifyView();
+        });
+}
+
+function destroyDBIfNeeded() {
+    console.log('destroying db');
+    return cloudant.db.list()
+        .then(existingDBs => {
+            if(existingDBs.indexOf(db_name) >= 0) {
+                console.log(`${db_name} already exists - DESTROY!`);
+                return cloudant.db.destroy(db_name);
+            }
+        });
+}
+
+function startDockerContainer(containerName) {
+    var dockerStartStopPromise = new Promise((resolve, reject) => {
+        var returnCode = shell.exec(`docker run -d --name ${containerName} -e CLOUDANT_USER=${cloudant_user} -e CLOUDANT_PASS=${cloudant_pass} openwhisk/kafkaprovider`).code
+
+        if(returnCode != 0) {
+            reject(`Failed to start docker container: ${returnCode}`);
+            return;
+        }
+
+        console.log("Giving the container some time to start up...");
+        setTimeout(function() {
+            console.log("Stopping the container");
+            var returnCode = shell.exec(`docker stop ${containerName}`).code;
+            if(returnCode != 0) {
+                reject('Failed to stop docker container');
+                return;
+            }
+
+            console.log("Deleting the container");
+            returnCode = shell.exec(`docker rm ${containerName}`).code;
+            if(returnCode != 0) {
+                reject('Failed to delete container');
+                return;
+            }
+
+            resolve();
+        }, 20000);
+    });
+
+    return dockerStartStopPromise;
+}
+
+function verifyView() {
+    var db = cloudant.db.use(db_name);
+
+    console.log('Verifying view exists and works as expected');
+    return ensureViewReturns(db, 0)
+        .then(() => {
+            return db.insert({
+                triggerURL: 'this is the only property needed by the view'
+            });
+        })
+        .then(() => {
+            // give it a few extra seconds to make sure the view is indexed
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    ensureViewReturns(db, 1)
+                        .then(resolve)
+                        .catch(reject);
+                }, 3000);
+            });
+        });
+}
+
+function ensureViewReturns(db, expectedNumberOfRows) {
+    return db.view('filters', 'only-triggers', {include_docs: false})
+        .then(results => {
+            if(results.rows.length != expectedNumberOfRows) {
+                return Promise.reject(`Expected view to contain ${expectedNumberOfRows} rows but got ${results.rows.length}`);
+            }
+        });
+}
+
+processArgs();
+verifyDBMigration()
+    .then(() => console.log('done!'))
+    .catch(err => console.error(JSON.stringify(err)));

--- a/tools/verifyDBMigration/package.json
+++ b/tools/verifyDBMigration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "verifyDBMigration",
+  "version": "0.0.1",
+  "dependencies": {
+    "cloudant": "^1.7.1",
+    "shelljs": "^0.7.7"
+  }
+}


### PR DESCRIPTION
This PR has two parts:
- A manual script to verify the DB migration process. This script verifies that the service provider can create a DB from scratch with the required view for retrieving triggers, as well as add the view to an existing DB. It only needs to be run once (I've run it).
- Cloudant was being very, _very_ slow as I was developing this script, and I noticed that when this happens, the situation can arise where the database migration is kicked off before the DB has actually been created. For this I have moved Database initialization to inside the `main` function.