### PR TITLE
HA - redundancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+.gradle
 launchConfigurations/
 *.pyc
+action/*.zip
+action/package.json
+tests/build

--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -1,0 +1,115 @@
+const common = require('./lib/common');
+const Database = require('./lib/Database');
+
+/**
+ *   Feed to listen to Kafka messages
+ *  @param {string} brokers - array of Kafka brokers
+ *  @param {string} topic - topic to subscribe to
+ *  @param {bool}   isJSONData - attempt to parse messages as JSON
+ *  @param {bool}   isBinaryKey - encode key as Base64
+ *  @param {bool}   isBinaryValue - encode message as Base64
+ *  @param {string} endpoint - address to OpenWhisk deployment (expected to be bound at deployment)
+ *  @param {string} DB_URL - URL for the DB, must include authentication (expected to be bound at deployment)
+ *  @param {string} DB_NAME - DB name (expected to be bound at deployment)
+ */
+function main(params) {
+    var promise = new Promise((resolve, reject) => {
+        // hold off initializing this until definitely needed
+        var db;
+
+        if (params.__ow_method === "put") {
+            return validateParameters(params)
+                .then(validatedParams => {
+                    console.log(`VALIDATED: ${JSON.stringify(validatedParams, null, 2)}`);
+                    db = new Database(params.DB_URL, params.DB_NAME);
+
+                    var promises = [];
+
+                    // do these in parallel!
+                    promises.push(db.ensureTriggerIsUnique(validatedParams.triggerName));
+                    promises.push(common.verifyTriggerAuth(validatedParams.triggerURL));
+
+                    return Promise.all(promises)
+                        .then(result => validatedParams);
+                })
+                .then(validatedParams => db.recordTrigger(validatedParams))
+                .then(result => {
+                    console.log('successfully wrote the trigger');
+                    resolve();
+                })
+                .catch(error => {
+                    console.log(`Failed to write the trigger ${error}`);
+
+                    // defaults to potentially be overridden
+                    var statusCode = 500;
+                    var body = error.toString();
+
+                    if(error.validationError) {
+                        statusCode = 400;
+                        body = error.validationError;
+                    } else if(error.authError) {
+                        statusCode = 401;
+                        body = error.authError;
+                    }
+
+                    resolve({
+                        statusCode: statusCode,
+                        headers: {'Content-Type': 'text/plain'},
+                        body: body
+                    });
+                });
+        } else if (params.__ow_method === "delete") {
+            const triggerURL = common.getTriggerURL(params.authKey, params.endpoint, params.triggerName);
+
+            return common.verifyTriggerAuth(triggerURL)
+                .then(() => {
+                    db = new Database(params.DB_URL, params.DB_NAME);
+                    return db.deleteTrigger(params.triggerName);
+                })
+                .then(resolve)
+                .catch(reject);
+        } else {
+            resolve({
+                statusCode: 400,
+                headers: {'Content-Type': 'text/plain'},
+                body: 'unsupported lifecycleEvent'
+            });
+        }
+    });
+
+    return promise;
+}
+
+function validateParameters(rawParams) {
+    var promise = new Promise((resolve, reject) => {
+        var validatedParams;
+
+        var commonValidationResult = common.performCommonParameterValidation(rawParams);
+        if(commonValidationResult.validationError) {
+            reject(commonValidationResult);
+            return;
+        } else {
+            validatedParams = commonValidationResult.validatedParams;
+        }
+
+        // brokers
+        if (rawParams.brokers) {
+            validatedParams.brokers = common.validateBrokerParam(rawParams.brokers);
+            if (!validatedParams.brokers) {
+                reject( { validationError: "You must supply a 'brokers' parameter as an array of Message Hub brokers." });
+                return;
+            }
+        } else {
+            reject( { validationError: "You must supply a 'brokers' parameter." });
+            return;
+        }
+
+        validatedParams.isMessageHub = false;
+
+        resolve(validatedParams);
+    });
+
+    return promise;
+}
+
+exports.main = main;

--- a/action/kafkaFeedWeb_package.json
+++ b/action/kafkaFeedWeb_package.json
@@ -1,0 +1,5 @@
+{
+  "name": "kafkaFeedWeb",
+  "version": "1.0.0",
+  "main": "kafkaFeedWeb.js"
+}

--- a/action/kafkaFeed_package.json
+++ b/action/kafkaFeed_package.json
@@ -1,0 +1,5 @@
+{
+  "name": "kafkaFeed",
+  "version": "1.0.0",
+  "main": "kafkaFeed.js"
+}

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -1,0 +1,63 @@
+// constructor for DB object - a thin, promise-loving wrapper around nano
+module.exports = function(dbURL, dbName) {
+    var nano = require('nano')(dbURL);
+    this.db = nano.db.use(dbName);
+
+    this.getTrigger = function(triggerFQN) {
+        return new Promise((resolve, reject) => {
+            this.db.get(triggerFQN, (err, result) => {
+                if(err) {
+                    reject(err);
+                } else {
+                    resolve(result);
+                }
+            });
+        });
+    };
+
+    this.ensureTriggerIsUnique = function(triggerFQN) {
+        return this.getTrigger(this.db, triggerFQN)
+            .then(result => {
+                return Promise.reject('Trigger already exists');
+            })
+            .catch(err => {
+                // turn that frown upside-down!
+                return true;
+            });
+    };
+
+    this.recordTrigger = function(params) {
+        console.log('recording trigger');
+
+        params['_id'] = params.triggerName;
+        params['status'] = {
+            'active': true,
+            'dateChanged': Math.round(new Date().getTime() / 1000)
+        };
+
+        return new Promise((resolve, reject) => {
+            this.db.insert(params, (err, result) => {
+                if(err) {
+                    reject(err);
+                } else {
+                    resolve(result);
+                }
+            });
+        });
+    };
+
+    this.deleteTrigger = function(triggerFQN) {
+        return this.getTrigger(triggerFQN)
+            .then(doc => {
+                return new Promise((resolve, reject) => {
+                    this.db.destroy(doc._id, doc._rev, (err, result) => {
+                        if(err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+                });
+            })
+    };
+};

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -1,0 +1,177 @@
+const request = require('request-promise');
+
+function triggerComponents(triggerName) {
+    var split = triggerName.split("/");
+
+    return {
+        namespace: split[1],
+        triggerName: split[2]
+    };
+}
+
+function getTriggerURL(authKey, endpoint, triggerName) {
+    var massagedAPIHost = endpoint.replace(/https?:\/\/(.*)/, "$1");
+
+    var components = triggerComponents(triggerName);
+    var namespace = components.namespace;
+    var trigger = components.triggerName;
+
+    var url = `https://${authKey}@${massagedAPIHost}/api/v1/namespaces/${encodeURIComponent(namespace)}/triggers/${encodeURIComponent(trigger)}`;
+
+    return url;
+}
+
+function verifyTriggerAuth(triggerURL) {
+    var options = {
+        method: 'GET',
+        url: triggerURL,
+        rejectUnauthorized: false,
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'whisk'
+        }
+    };
+
+    return request(options)
+        .catch(err => {
+            console.log(`Trigger auth error: ${JSON.stringify(err)}`);
+            return Promise.reject({ authError: 'You are not authorized for this trigger.'});
+        });
+}
+
+function validateBrokerParam(brokerParam) {
+    if (isNonEmptyArray(brokerParam)) {
+        return brokerParam;
+    } else if (typeof brokerParam === 'string') {
+        return brokerParam.split(',');
+    } else {
+        return undefined;
+    }
+}
+
+function getBooleanFromArgs(args, key) {
+    return (typeof args[key] !== 'undefined' && args[key] && (args[key] === true || args[key].toString().trim().toLowerCase() === 'true'));
+}
+
+function isNonEmptyArray(obj) {
+    return obj && Array.isArray(obj) && obj.length !== 0;
+}
+
+// Return the trigger FQN with the resolved namespace
+// This is required to avoid naming conflicts when using the default namespace "_"
+function getTriggerFQN(triggerName) {
+    var components = triggerName.split('/');
+    return `/${process.env['__OW_NAMESPACE']}/${components[2]}`;
+}
+
+function massageParamsForWeb(rawParams) {
+    var massagedParams = Object.assign({}, rawParams);
+
+    // remove these parameters as they may conflict with bound parameters of the web action
+    delete massagedParams.endpoint;
+    delete massagedParams.bluemixServiceName;
+    delete massagedParams.lifecycleEvent;
+
+    return massagedParams;
+}
+
+function getWebActionURL(endpoint, actionName) {
+    return `https://${endpoint}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
+}
+
+function createTrigger(endpoint, params, actionName) {
+    var options = {
+        method: 'PUT',
+        url: getWebActionURL(endpoint, actionName),
+        rejectUnauthorized: false,
+        json: true,
+        body: params,
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/plain',
+            'User-Agent': 'whisk'
+        }
+    };
+
+    return request(options)
+        .then(response => {
+            // do not pass the response back to the caller, its contents are secret
+            return;
+        })
+        .catch(error => {
+            console.log(`Error creating trigger: ${JSON.stringify(error, null, 2)}`);
+            return Promise.reject(error.response.body);
+        });
+}
+
+function deleteTrigger(endpoint, params, actionName) {
+    var options = {
+        method: 'DELETE',
+        url: getWebActionURL(endpoint, actionName),
+        rejectUnauthorized: false,
+        json: true,
+        body: params,
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/plain',
+            'User-Agent': 'whisk'
+        }
+    };
+
+    return request(options)
+        .then(response => {
+            // do not pass the response back to the caller, its contents are secret
+            return;
+        }).catch(error => {
+            console.log(`Error deleting trigger: ${JSON.stringify(error, null, 2)}`);
+            return Promise.reject(error.response.body);
+        });
+}
+
+// perform parameter validation that is common to both feed actions
+function performCommonParameterValidation(rawParams) {
+    var validatedParams = {};
+
+    // topic
+    if (rawParams.topic && rawParams.topic.length > 0) {
+        validatedParams.topic = rawParams.topic;
+    } else {
+        return { validationError: "You must supply a 'topic' parameter." };
+    }
+
+    // triggerName
+    if (rawParams.triggerName) {
+        validatedParams.triggerName = rawParams.triggerName;
+    } else {
+        return { validationError: "You must supply a 'triggerName' parameter." };
+    }
+
+    validatedParams.isJSONData = getBooleanFromArgs(rawParams, 'isJSONData');
+    validatedParams.isBinaryValue = getBooleanFromArgs(rawParams, 'isBinaryValue');
+
+    if (validatedParams.isJSONData && validatedParams.isBinaryValue) {
+        return { validationError: 'isJSONData and isBinaryValue cannot both be enabled.' };
+    }
+
+    // now that everything else is valid, let's add these
+    validatedParams.isBinaryKey = getBooleanFromArgs(rawParams, 'isBinaryKey');
+    validatedParams.authKey = rawParams.authKey;
+    validatedParams.triggerURL = getTriggerURL(validatedParams.authKey, rawParams.endpoint, rawParams.triggerName);
+
+    const uuid = require('uuid');
+    validatedParams.uuid = uuid.v4();
+
+    return { validatedParams: validatedParams };
+}
+
+module.exports = {
+    'createTrigger': createTrigger,
+    'deleteTrigger': deleteTrigger,
+    'getBooleanFromArgs': getBooleanFromArgs,
+    'getTriggerFQN': getTriggerFQN,
+    'getTriggerURL': getTriggerURL,
+    'massageParamsForWeb': massageParamsForWeb,
+    'performCommonParameterValidation': performCommonParameterValidation,
+    'validateBrokerParam': validateBrokerParam,
+    'verifyTriggerAuth': verifyTriggerAuth,
+};

--- a/action/messageHubFeed.js
+++ b/action/messageHubFeed.js
@@ -1,4 +1,4 @@
-var request = require('request');
+const common = require('./lib/common');
 
 /**
  *   Feed to listen to MessageHub messages
@@ -9,213 +9,24 @@ var request = require('request');
  *  @param {bool}   isJSONData - attempt to parse messages as JSON
  *  @param {bool}   isBinaryKey - encode key as Base64
  *  @param {bool}   isBinaryValue - encode message as Base64
- *  @param {string} endpoint - address to OpenWhisk deployment
+ *  @param {string} endpoint - address to OpenWhisk deployment (expected to be bound at deployment)
  */
 function main(params) {
-    var promise = new Promise(function(resolve, reject) {
-        if(!params.package_endpoint) {
-            reject('Could not find the package_endpoint parameter.');
-            return;
-        }
+    const endpoint = params.endpoint;
+    const webActionName = 'messageHubFeedWeb'
 
-        var triggerComponents = params.triggerName.split("/");
-        var namespace = encodeURIComponent(process.env['__OW_NAMESPACE']);
-        var trigger = encodeURIComponent(triggerComponents[2]);
-        var feedServiceURL = 'http://' + params.package_endpoint + '/triggers/' + namespace + '/' + trigger;
+    var massagedParams = common.massageParamsForWeb(params);
+    massagedParams.triggerName = common.getTriggerFQN(params.triggerName);
 
-        if (params.lifecycleEvent === 'CREATE') {
-            // makes a PUT request to create the trigger in the feed service provider
-            var putTrigger = function(validatedParams) {
-                var body = validatedParams;
-
-                // params.endpoint may already include the protocol - if so,
-                // strip it out
-                var massagedAPIHost = params.endpoint.replace(/https?:\/\/(.*)/, "$1");
-                body.triggerURL = 'https://' + process.env['__OW_API_KEY'] + "@" + massagedAPIHost + '/api/v1/namespaces/' + namespace + '/triggers/' + trigger;
-
-                var options = {
-                    method: 'PUT',
-                    url: feedServiceURL,
-                    body: JSON.stringify(body),
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'User-Agent': 'whisk'
-                    }
-                };
-
-                return doRequest(options);
-            };
-
-            return validateParameters(params)
-                .then(checkMessageHubCredentials)
-                .then(putTrigger)
-                .then(resolve)
-                .catch(reject);
-        } else if (params.lifecycleEvent === 'DELETE') {
-            var authorizationHeader = 'Basic ' + new Buffer(process.env['__OW_API_KEY']).toString('base64');
-
-            var options = {
-                method: 'DELETE',
-                url: feedServiceURL,
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': authorizationHeader,
-                    'User-Agent': 'whisk'
-                }
-            };
-
-            doRequest(options)
-                .then(resolve)
-                .catch(reject);
-        }
-    });
-
-    return promise;
-}
-
-function checkMessageHubCredentials(params) {
-    // make sure we have valid MH credentials
-    console.log("Checking Message Hub credentials...");
-
-    // listing topics seems to be the simplest way to check auth
-    var topicURL = params.kafka_admin_url + '/admin/topics';
-
-    var options = {
-        method: 'GET',
-        url: topicURL,
-        headers: {
-            'X-Auth-Token': params.username + params.password
-        }
-    };
-
-    return doRequest(options)
-        .then(function(body) {
-            console.log("Successfully authenticated with Message Hub");
-
-            var topicNames = body.response.map(function(topic) {
-                return topic.name
-            });
-
-            if(topicNames.indexOf(params.topic) < 0) {
-                return Promise.reject('Topic does not exist. You must create the topic first: ' + params.topic);
-            } else {
-                console.log("Topic exists.");
-                // return the params so they can be chained into the next function
-                return params;
-            }
-        }, function(authError) {
-            return Promise.reject('Could not authenticate with Message Hub. Please check your credentials.');
-        });
-}
-
-function doRequest(options) {
-    var requestPromise = new Promise(function (resolve, reject) {
-        request(options, function (error, response, body) {
-            if (error) {
-                reject({
-                    response: response,
-                    error: error,
-                    body: JSON.parse(body)
-                });
-            } else {
-                console.log("Status code: " + response.statusCode);
-
-                if (response.statusCode >= 400) {
-                    console.log("Response: " + JSON.stringify(body));
-                    reject({
-                        statusCode: response.statusCode,
-                        response: JSON.parse(body)
-                    });
-                } else {
-                    resolve({
-                        response: JSON.parse(body)
-                    });
-                }
-            }
-        });
-    });
-
-    return requestPromise;
-}
-
-function validateParameters(rawParams) {
-    var promise = new Promise(function(resolve, reject) {
-        var validatedParams = {};
-
-        validatedParams.isMessageHub = true;
-        validatedParams.isJSONData = getBooleanFromArgs(rawParams, 'isJSONData');
-        validatedParams.isBinaryValue = getBooleanFromArgs(rawParams, 'isBinaryValue');
-        validatedParams.isBinaryKey = getBooleanFromArgs(rawParams, 'isBinaryKey');
-
-        if (validatedParams.isJSONData && validatedParams.isBinaryValue) {
-            reject('isJSONData and isBinaryValue cannot both be enabled.');
-            return;
-        }
-
-        // topic
-        if (rawParams.topic && rawParams.topic.length > 0) {
-            validatedParams.topic = rawParams.topic;
-        } else {
-            reject('You must supply a "topic" parameter.');
-            return;
-        }
-
-        // kafka_brokers_sasl
-        if (rawParams.kafka_brokers_sasl) {
-            validatedParams.brokers = validateBrokerParam(rawParams.kafka_brokers_sasl);
-            if(!validatedParams.brokers) {
-                reject('You must supply a "kafka_brokers_sasl" parameter as an array of Message Hub brokers.');
-                return;
-            }
-        } else {
-            reject('You must supply a "kafka_brokers_sasl" parameter as an array of Message Hub brokers.');
-            return;
-        }
-
-        // user
-        if (rawParams.user) {
-            validatedParams.username = rawParams.user;
-        } else {
-            reject('You must supply a "user" parameter to authenticate with Message Hub.');
-            return;
-        }
-
-        // password
-        if (rawParams.password) {
-            validatedParams.password = rawParams.password;
-        } else {
-            reject('You must supply a "password" parameter to authenticate with Message Hub.');
-            return;
-        }
-
-        // kafka_admin_url
-        if(rawParams.kafka_admin_url) {
-            validatedParams.kafka_admin_url = rawParams.kafka_admin_url;
-        } else {
-            reject('You must supply a "kafka_admin_url" parameter.');
-            return;
-        }
-
-        resolve(validatedParams);
-    });
-
-    return promise;
-}
-
-function validateBrokerParam(brokerParam) {
-    if(isNonEmptyArray(brokerParam)) {
-        return brokerParam;
-    } else if (typeof brokerParam === 'string') {
-        return brokerParam.split(',');
-    } else {
-        return undefined;
+    if (params.lifecycleEvent === 'CREATE') {
+        return common.createTrigger(endpoint, massagedParams, webActionName);
+    } else if (params.lifecycleEvent === 'DELETE') {
+        return common.deleteTrigger(endpoint, massagedParams, webActionName);
     }
+
+    return {
+        error: 'unsupported lifecycleEvent'
+    };
 }
 
-function getBooleanFromArgs(args, key) {
-  return (typeof args[key] !== 'undefined' && args[key] && (args[key] === true || args[key].toString().trim().toLowerCase() === 'true'));
-}
-
-function isNonEmptyArray(obj) {
-    return obj && Array.isArray(obj) && obj.length !== 0;
-}
+exports.main = main;

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -1,0 +1,174 @@
+const common = require('./lib/common');
+const Database = require('./lib/Database');
+
+/**
+ *   Feed to listen to MessageHub messages
+ *  @param {string} brokers - array of Message Hub brokers
+ *  @param {string} username - Kafka username
+ *  @param {string} password - Kafka password
+ *  @param {string} topic - topic to subscribe to
+ *  @param {bool}   isJSONData - attempt to parse messages as JSON
+ *  @param {bool}   isBinaryKey - encode key as Base64
+ *  @param {bool}   isBinaryValue - encode message as Base64
+ *  @param {string} endpoint - address to OpenWhisk deployment (expected to be bound at deployment)
+ *  @param {string} DB_URL - URL for the DB, must include authentication (expected to be bound at deployment)
+ *  @param {string} DB_NAME - DB name (expected to be bound at deployment)
+ */
+function main(params) {
+    var promise = new Promise((resolve, reject) => {
+        // hold off initializing this until definitely needed
+        var db;
+
+        if (params.__ow_method === "put") {
+            return validateParameters(params)
+                .then(validatedParams => {
+                    console.log(`VALIDATED: ${JSON.stringify(validatedParams, null, 2)}`);
+                    db = new Database(params.DB_URL, params.DB_NAME);
+
+                    var promises = [];
+
+                    // do these in parallel!
+                    promises.push(db.ensureTriggerIsUnique(validatedParams.triggerName));
+                    promises.push(common.verifyTriggerAuth(validatedParams.triggerURL));
+                    promises.push(checkMessageHubCredentials(validatedParams));
+
+                    return Promise.all(promises)
+                        .then(result => validatedParams);
+                })
+                .then(validatedParams => db.recordTrigger(validatedParams))
+                .then(result => {
+                    console.log('successfully wrote the trigger');
+                    resolve();
+                })
+                .catch(error => {
+                    console.log(`Failed to write the trigger ${error}`);
+
+                    // defaults to potentially be overridden
+                    var statusCode = 500;
+                    var body = error.toString();
+
+                    if(error.validationError) {
+                        statusCode = 400;
+                        body = error.validationError;
+                    } else if(error.authError) {
+                        statusCode = 401;
+                        body = error.authError;
+                    }
+
+                    resolve({
+                        statusCode: statusCode,
+                        headers: {'Content-Type': 'text/plain'},
+                        body: body
+                    });
+                });
+        } else if (params.__ow_method === "delete") {
+            const triggerURL = common.getTriggerURL(params.authKey, params.endpoint, params.triggerName);
+
+            return common.verifyTriggerAuth(triggerURL)
+                .then(() => {
+                    db = new Database(params.DB_URL, params.DB_NAME);
+                    return db.deleteTrigger(params.triggerName);
+                })
+                .then(resolve)
+                .catch(reject);
+        } else {
+            resolve({
+                statusCode: 400,
+                headers: {'Content-Type': 'text/plain'},
+                body: 'unsupported lifecycleEvent'
+            });
+        }
+    });
+
+    return promise;
+}
+
+function validateParameters(rawParams) {
+    var promise = new Promise((resolve, reject) => {
+        var validatedParams;
+
+        var commonValidationResult = common.performCommonParameterValidation(rawParams);
+        if(commonValidationResult.validationError) {
+            reject(commonValidationResult);
+            return;
+        } else {
+            validatedParams = commonValidationResult.validatedParams;
+        }
+
+        // kafka_brokers_sasl
+        if (rawParams.kafka_brokers_sasl) {
+            validatedParams.brokers = common.validateBrokerParam(rawParams.kafka_brokers_sasl);
+            if (!validatedParams.brokers) {
+                reject( { validationError: "You must supply a 'kafka_brokers_sasl' parameter as an array of Message Hub brokers." });
+                return;
+            }
+        } else {
+            reject( { validationError: "You must supply a 'kafka_brokers_sasl' parameter." });
+            return;
+        }
+
+        // user
+        if (rawParams.user) {
+            validatedParams.username = rawParams.user;
+        } else {
+            reject( { validationError: "You must supply a 'user' parameter to authenticate with Message Hub." });
+            return;
+        }
+
+        // password
+        if (rawParams.password) {
+            validatedParams.password = rawParams.password;
+        } else {
+            reject( { validationError: "You must supply a 'password' parameter to authenticate with Message Hub." });
+            return;
+        }
+
+        // kafka_admin_url
+        if (rawParams.kafka_admin_url) {
+            validatedParams.kafka_admin_url = rawParams.kafka_admin_url;
+        } else {
+            reject( { validationError: "You must supply a 'kafka_admin_url' parameter." });
+            return;
+        }
+
+        validatedParams.isMessageHub = true;
+
+        resolve(validatedParams);
+    });
+
+    return promise;
+}
+
+function checkMessageHubCredentials(params) {
+    // listing topics seems to be the simplest way to check auth
+    var topicURL = params.kafka_admin_url + '/admin/topics';
+
+    var options = {
+        method: 'GET',
+        url: topicURL,
+        json: true,
+        headers: {
+            'X-Auth-Token': params.username + params.password
+        }
+    };
+
+    const request = require('request-promise');
+
+    return request(options)
+        .then(body => {
+            console.log("Successfully authenticated with Message Hub");
+
+            var topicNames = body.map(topic => {
+                return topic.name
+            });
+
+            if (topicNames.indexOf(params.topic) < 0) {
+                return Promise.reject( 'Topic does not exist. You must create the topic first: ' + params.topic );
+            }
+        }, function (authError) {
+            console.log(`authError: ${JSON.stringify(authError)}`);
+            return Promise.reject( 'Could not authenticate with Message Hub. Please check your credentials.' );
+        });
+}
+
+exports.main = main;

--- a/action/messageHubFeedWeb_package.json
+++ b/action/messageHubFeedWeb_package.json
@@ -1,0 +1,5 @@
+{
+  "name": "messageHubFeedWeb",
+  "version": "1.0.0",
+  "main": "messageHubFeedWeb.js"
+}

--- a/action/messageHubFeed_package.json
+++ b/action/messageHubFeed_package.json
@@ -1,0 +1,5 @@
+{
+  "name": "messageHubFeed",
+  "version": "1.0.0",
+  "main": "messageHubFeed.js"
+}

--- a/installKafka.sh
+++ b/installKafka.sh
@@ -4,8 +4,8 @@
 # automatically
 #
 # To run this command
-# ./installKafka.sh  <AUTH> <EDGEHOST> <KAFKA_TRIGGER_HOST> <KAFKA_TRIGGER_PORT> <APIHOST>
-# AUTH and APIHOST are found in $HOME/.wskprops
+# ./installKafka.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost>
+# authkey and apihost are found in $HOME/.wskprops
 
 set -e
 set -x
@@ -15,15 +15,14 @@ WSK_CLI="$OPENWHISK_HOME/bin/wsk"
 
 if [ $# -eq 0 ]
 then
-echo "Usage: ./installCatalog.sh <authkey> <apihost> <kafkatriggerhost> <kafkatriggerport>"
+echo "Usage: ./installKafka.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost>"
 fi
 
 AUTH="$1"
 EDGEHOST="$2"
-KAFKA_TRIGGER_HOST="$3"
-KAFKA_TRIGGER_PORT="$4"
+DB_URL="$3"
+DB_NAME="${4}ow_kafka_triggers"
 APIHOST="$5"
-
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.
@@ -34,19 +33,60 @@ fi
 # Make sure that the APIHOST is not empty.
 : ${APIHOST:?"APIHOST must be set and non-empty"}
 
-KAFKA_PROVIDER_ENDPOINT=$KAFKA_TRIGGER_HOST':'$KAFKA_TRIGGER_PORT
-
 PACKAGE_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
 
-echo Installing the kafka feed action.
+echo Installing the Kafka package and feed action.
 
-$WSK_CLI -i --apihost "$EDGEHOST" action update messaging/kafkaFeed "$PACKAGE_HOME/action/kafkaFeed.js" \
+# make kafkaFeed.zip
+OLD_PATH=`pwd`
+cd action
+
+if [ -e kafkaFeed.zip ]
+then
+    rm -rf kafkaFeed.zip
+fi
+
+cp -f kafkaFeed_package.json package.json
+zip -r kafkaFeed.zip lib package.json kafkaFeed.js
+cd $OLD_PATH
+
+$WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messaging/kafkaFeed "$PACKAGE_HOME/action/kafkaFeed.zip" \
     --auth "$AUTH" \
+    -a feed true \
     -a description 'Feed to listen to Kafka messages' \
     -a parameters '[ {"name":"brokers", "required":true, "description": "Array of Kafka brokers"}, {"name":"topic", "required":true, "description": "Topic to subscribe to"}, {"name":"isJSONData", "required":false, "description": "Attempt to parse message value as JSON"}, {"name":"isBinaryKey", "required":false, "description": "Encode key as Base64"}, {"name":"isBinaryValue", "required":false, "description": "Encode message value as Base64"}, {"name":"endpoint", "required":true, "description": "Hostname and port of OpenWhisk deployment"}]' \
     -a sampleInput '{"brokers":"[\"127.0.0.1:9093\"]", "topic":"mytopic", "isJSONData":"false", "endpoint": "openwhisk.ng.bluemix.net"}'
+
+# create messagingWeb package and web version of feed action
+$WSK_CLI -i --apihost "$EDGEHOST" package update messagingWeb \
+    --auth "$AUTH" \
+    --shared no \
+    -p endpoint "$APIHOST" \
+    -p DB_URL "$DB_URL" \
+    -p DB_NAME "$DB_NAME" \
+
+# make kafkaFeedWeb.zip
+OLD_PATH=`pwd`
+cd action
+
+if [ -e kafkaFeedWeb.zip ]
+then
+    rm -rf kafkaFeedWeb.zip
+fi
+
+cp -f kafkaFeedWeb_package.json package.json
+zip -r kafkaFeedWeb.zip lib package.json kafkaFeedWeb.js
+
+cd $OLD_PATH
+
+
+$WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/kafkaFeedWeb "$PACKAGE_HOME/action/kafkaFeedWeb.zip" \
+    --auth "$AUTH" \
+    --web true \
+    -a description 'Write a new trigger to Kafka provider DB' \
+    -a parameters '[ {"name":"brokers", "required":true, "description": "Array of Kafka brokers"},{"name":"topic", "required":true, "description": "Topic to subscribe to"},{"name":"isJSONData", "required":false, "description": "Attempt to parse message value as JSON"},{"name":"isBinaryKey", "required":false, "description": "Encode key as Base64"},{"name":"isBinaryValue", "required":false, "description": "Encode message value as Base64"},{"name":"endpoint", "required":true, "description": "Hostname and port of OpenWhisk deployment"}]'
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/kafkaProduce "$PACKAGE_HOME/action/kafkaProduce.py" \
     --auth "$AUTH" \

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -61,6 +61,9 @@ class Consumer:
     def shutdown(self):
         self.thread.shutdown()
 
+    def disable(self):
+        self.thread.setDesiredState(Consumer.State.Disabled)
+
     def start(self):
         self.thread.start()
 
@@ -216,7 +219,6 @@ class ConsumerThread (Thread):
 
         if self.desiredState() == Consumer.State.Dead:
             logging.info('[{}] Permanently killing consumer because desired state is Dead'.format(self.trigger))
-            self.database.deleteTrigger(self.trigger)
         elif self.desiredState() == Consumer.State.Restart:
             logging.info('[{}] Quietly letting the consumer thread stop in order to allow restart.'.format(self.trigger))
             # nothing else to do because this Thread is about to go away

--- a/provider/health.py
+++ b/provider/health.py
@@ -14,7 +14,6 @@
 
 import psutil   # https://pythonhosted.org/psutil/
 
-from consumercollection import ConsumerCollection
 from datetime import datetime
 
 MILLISECONDS_IN_SECOND = 1000
@@ -118,7 +117,6 @@ def getUpdateTime():
 
 def getConsumers(consumers):
     consumerReports = []
-    currentTime = datetime.now()
 
     consumerCopyRO = consumers.getCopyForRead()
     for consumerId in consumerCopyRO:

--- a/provider/service.py
+++ b/provider/service.py
@@ -1,0 +1,89 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from consumer import Consumer
+from database import Database
+from threading import Thread
+
+class Service (Thread):
+    def __init__(self, consumers):
+        Thread.__init__(self)
+        self.daemon = True
+
+        self.changes = Database().changesFeed()
+        self.consumers = consumers
+
+    def run(self):
+        while True:
+            for change in self.changes:
+                if "deleted" in change and change["deleted"] == True:
+                    logging.info('[changes] Found a delete')
+                    consumer = self.consumers.getConsumerForTrigger(change['id'])
+                    if consumer != None:
+                        if consumer.desiredState() == Consumer.State.Disabled:
+                            # just remove it from memory
+                            logging.info('[{}] Removing disabled trigger'.format(consumer.trigger))
+                            self.consumers.removeConsumerForTrigger(consumer.trigger)
+                        else:
+                            logging.info('[{}] Shutting down running trigger'.format(consumer.trigger))
+                            consumer.shutdown()
+                # since we can't use a filter function for the feed (then
+                # you don't get deletes) we need to manually verify this
+                # is a valid trigger doc that has changed
+                elif 'triggerURL' in change['doc']:
+                    logging.info('[changes] Found a change in a trigger document')
+                    document = change['doc']
+
+                    if not self.consumers.hasConsumerForTrigger(change["id"]):
+                        logging.info('[{}] Found a new trigger to create'.format(change["id"]))
+                        self.createAndRunConsumer(document)
+                    else:
+                        logging.info('[{}] Found a change to an existing trigger'.format(change["id"]))
+                        existingConsumer = self.consumers.getConsumerForTrigger(change["id"])
+
+                        if existingConsumer.desiredState() == Consumer.State.Disabled and self.__isTriggerDocActive(document):
+                            # disabled trigger has become active
+                            logging.info('[{}] Existing disabled trigger should become active'.format(change["id"]))
+                            self.createAndRunConsumer(document)
+                        elif existingConsumer.desiredState() == Consumer.State.Running and not self.__isTriggerDocActive(document):
+                            # running trigger should become disabled
+                            logging.info('[{}] Existing running trigger should become disabled'.format(change["id"]))
+                            existingConsumer.disable()
+                        else:
+                            logging.debug('[changes] Found non-interesting trigger change: \n{}\n{}'.format(existingConsumer.desiredState(), document))
+                else:
+                    logging.debug('[changes] Found a change for a non-trigger document')
+
+            logging.error("[changes] uh-oh! I made it out of the changes for loop!")
+
+
+    def createAndRunConsumer(self, doc):
+        triggerFQN = doc['_id']
+
+        # Create a representation for this trigger, even if it is disabled
+        # This allows it to appear in /health as well as allow it to be deleted
+        # Creating this object is lightweight and does not initialize any connections
+        consumer = Consumer(triggerFQN, doc)
+        self.consumers.addConsumerForTrigger(triggerFQN, consumer)
+
+        if self.__isTriggerDocActive(doc):
+            logging.info('[{}] Trigger was determined to be active, starting...'.format(triggerFQN))
+            consumer.start()
+        else:
+            logging.info('[{}] Trigger was determined to be disabled, not starting...'.format(triggerFQN))
+
+    def __isTriggerDocActive(self, doc):
+        return ('status' not in doc or doc['status']['active'] == True)

--- a/provider/thedoctor.py
+++ b/provider/thedoctor.py
@@ -2,7 +2,6 @@ import logging
 import time
 
 from consumer import Consumer
-from consumercollection import ConsumerCollection
 from threading import Thread
 
 class TheDoctor (Thread):

--- a/tests/dat/multipleValueTypes.json
+++ b/tests/dat/multipleValueTypes.json
@@ -2,6 +2,9 @@
   "kafka_brokers_sasl": [
     "someBroker"
   ],
+  "brokers": [
+    "someBroker"
+  ],
   "topic": "someTopic",
   "user": "someUser",
   "password": "somePassword",

--- a/tests/src/test/scala/system/packages/KafkaFeedTests.scala
+++ b/tests/src/test/scala/system/packages/KafkaFeedTests.scala
@@ -42,24 +42,16 @@ class KafkaFeedTests
 
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
-  val actionName = "kafkaFeedAction"
-  val actionFile = "../action/kafkaFeed.js"
+
+  val messagingPackage = "/whisk.system/messaging"
+  val kafkaFeed = "kafkaFeed"
+  val actionName = s"${messagingPackage}/${kafkaFeed}"
 
   behavior of "Kafka feed action"
 
-  override def beforeAll() {
-    wsk.action.create(actionName, Some(actionFile))
-    super.beforeAll()
-  }
-
-  override def afterAll()  {
-    wsk.action.delete(actionName)
-    super.afterAll()
-  }
-
   it should "reject invocation when topic argument is missing" in {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"topic\" parameter.")
+      "error" -> JsString("You must supply a 'topic' parameter.")
     )
 
     runActionWithExpectedResult(actionName, "dat/missingTopic.json", expectedOutput, false)
@@ -67,18 +59,10 @@ class KafkaFeedTests
 
   it should "reject invocation when brokers argument is missing" in  {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"brokers\" parameter as an array of Kafka brokers.")
+      "error" -> JsString("You must supply a 'brokers' parameter.")
     )
 
     runActionWithExpectedResult(actionName, "dat/missingBrokers.json", expectedOutput, false)
-  }
-
-  it should "reject invocation when package_endpoint argument is missing" in {
-    val expectedOutput = JsObject(
-      "error" -> JsString("Could not find the package_endpoint parameter.")
-    )
-
-    runActionWithExpectedResult(actionName, "dat/missingPackageEndpoint.json", expectedOutput, false)
   }
 
   it should "reject invocation when isJSONData and isBinaryValue are both enable" in {

--- a/tests/src/test/scala/system/packages/KafkaFeedWebTests.scala
+++ b/tests/src/test/scala/system/packages/KafkaFeedWebTests.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package system.packages
+
+import org.junit.runner.RunWith
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import com.jayway.restassured.RestAssured
+import com.jayway.restassured.config.SSLConfig
+
+import common.Wsk
+import common.WskProps
+import common.TestUtils.FORBIDDEN
+
+import spray.json._
+
+@RunWith(classOf[JUnitRunner])
+class KafkaFeedWebTests
+  extends FlatSpec
+    with BeforeAndAfter
+    with Matchers {
+
+  val wskprops = WskProps()
+
+  val webAction = "/whisk.system/messagingWeb/kafkaFeedWeb"
+  val webActionURL = s"https://${wskprops.apihost}/api/v1/web${webAction}.http"
+
+  val completeParams = JsObject(
+    "triggerName" -> JsString("/invalidNamespace/invalidTrigger"),
+    "topic" -> JsString("someTopic"),
+    "brokers" -> JsArray(JsString("someBroker")),
+    "user" -> JsString("someUsername"),
+    "password" -> JsString("somePassword"),
+    "kafka_admin_url" -> JsString("https://kafka-admin-prod01.messagehub.services.us-south.bluemix.net:443"),
+    "authKey" -> JsString("DoesNotWork")
+  )
+
+  def makePutCallWithExpectedResult(params: JsObject, expectedResult: String, expectedCode: Int) = {
+    val response = RestAssured.given()
+        .contentType("application/json\r\n")
+        .config(RestAssured.config().sslConfig(new SSLConfig().relaxedHTTPSValidation()))
+        .body(params.toString())
+        .put(webActionURL)
+    assert(response.statusCode() == expectedCode)
+    response.body.asString shouldBe expectedResult
+  }
+
+  def makeDeleteCallWithExpectedResult(expectedResult: String, expectedCode: Int) = {
+    val response = RestAssured.given().contentType("application/json\r\n").config(RestAssured.config().sslConfig(new SSLConfig().relaxedHTTPSValidation())).delete(webActionURL)
+    assert(response.statusCode() == expectedCode)
+    response.body.asString shouldBe expectedResult
+  }
+
+  behavior of "Kafka feed web action"
+
+  it should "not be obtainable using the CLI" in {
+      val wsk = new Wsk()
+      implicit val wp = wskprops
+
+      wsk.action.get(webAction, FORBIDDEN)
+  }
+
+  it should "reject post of a trigger due to missing brokers argument" in {
+    val params = JsObject(completeParams.fields - "brokers")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'brokers' parameter.", 400)
+  }
+
+  it should "reject post of a trigger due to missing topic argument" in {
+    val params = JsObject(completeParams.fields - "topic")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'topic' parameter.", 400)
+  }
+
+  it should "reject post of a trigger due to missing triggerName argument" in {
+    val params = JsObject(completeParams.fields - "triggerName")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'triggerName' parameter.", 400)
+  }
+
+  it should "reject put of a trigger when authentication fails" in {
+    makePutCallWithExpectedResult(completeParams, "You are not authorized for this trigger.", 401)
+  }
+
+  // it should "reject delete of a trigger that does not exist" in {
+  //   val expectedJSON = JsObject(
+  //     "triggerName" -> JsString("/invalidNamespace/invalidTrigger"),
+  //     "error" -> JsString("not found")
+  //   )
+  //
+  //   makeDeleteCallWithExpectedResult(expectedJSON, 404)
+  // }
+}

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -67,61 +67,48 @@ class MessageHubFeedTests
 
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
-  val actionName = "messageHubFeedAction"
-  val actionFile = "../action/messageHubFeed.js"
+  val actionName = s"${messagingPackage}/${messageHubFeed}"
 
   behavior of "Message Hub feed action"
 
-  override def beforeAll() {
-    wsk.action.create(actionName, Some(actionFile))
-    super.beforeAll()
-  }
-
-  override def afterAll() {
-    wsk.action.delete(actionName)
-    super.afterAll()
-  }
-
   it should "reject invocation when topic argument is missing" in {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"topic\" parameter."))
+      "error" -> JsString("You must supply a 'topic' parameter.")
+    )
 
     runActionWithExpectedResult(actionName, "dat/missingTopic.json", expectedOutput, false)
   }
 
   it should "reject invocation when kafka_brokers_sasl argument is missing" in {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"kafka_brokers_sasl\" parameter as an array of Message Hub brokers."))
+      "error" -> JsString("You must supply a 'kafka_brokers_sasl' parameter.")
+    )
 
     runActionWithExpectedResult(actionName, "dat/missingBrokers.json", expectedOutput, false)
   }
 
   it should "reject invocation when kafka_admin_url argument is missing" in {
     val expectedOutput = JsObject("error" -> JsString(
-      "You must supply a \"kafka_admin_url\" parameter."))
+      "You must supply a 'kafka_admin_url' parameter.")
+    )
 
     runActionWithExpectedResult(actionName, "dat/missingAdminURL.json", expectedOutput, false)
   }
 
   it should "reject invocation when user argument is missing" in {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"user\" parameter to authenticate with Message Hub."))
+      "error" -> JsString("You must supply a 'user' parameter to authenticate with Message Hub.")
+    )
 
     runActionWithExpectedResult(actionName, "dat/missingUser.json", expectedOutput, false)
   }
 
   it should "reject invocation when password argument is missing" in {
     val expectedOutput = JsObject(
-      "error" -> JsString("You must supply a \"password\" parameter to authenticate with Message Hub."))
+      "error" -> JsString("You must supply a 'password' parameter to authenticate with Message Hub.")
+    )
 
     runActionWithExpectedResult(actionName, "dat/missingPassword.json", expectedOutput, false)
-  }
-
-  it should "reject invocation when package_endpoint argument is missing" in {
-    val expectedOutput = JsObject(
-      "error" -> JsString("Could not find the package_endpoint parameter."))
-
-    runActionWithExpectedResult(actionName, "dat/missingPackageEndpoint.json", expectedOutput, false)
   }
 
   it should "reject invocation when isJSONData and isBinaryValue are both enable" in {

--- a/tests/src/test/scala/system/packages/MessageHubFeedWebTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedWebTests.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package system.packages
+
+import org.junit.runner.RunWith
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import com.jayway.restassured.RestAssured
+import com.jayway.restassured.config.SSLConfig
+
+import common.Wsk
+import common.WskProps
+import common.TestUtils.FORBIDDEN
+
+import spray.json._
+
+@RunWith(classOf[JUnitRunner])
+class MessageHubFeedWebTests
+  extends FlatSpec
+    with BeforeAndAfter
+    with Matchers {
+
+  val wskprops = WskProps()
+
+  val webAction = "/whisk.system/messagingWeb/messageHubFeedWeb"
+  val webActionURL = s"https://${wskprops.apihost}/api/v1/web${webAction}.http"
+
+  val completeParams = JsObject(
+    "triggerName" -> JsString("/invalidNamespace/invalidTrigger"),
+    "topic" -> JsString("someTopic"),
+    "kafka_brokers_sasl" -> JsArray(JsString("someBroker")),
+    "user" -> JsString("someUsername"),
+    "password" -> JsString("somePassword"),
+    "kafka_admin_url" -> JsString("https://kafka-admin-prod01.messagehub.services.us-south.bluemix.net:443"),
+    "authKey" -> JsString("DoesNotWork")
+  )
+
+  def makePutCallWithExpectedResult(params: JsObject, expectedResult: String, expectedCode: Int) = {
+    val response = RestAssured.given()
+        .contentType("application/json\r\n")
+        .config(RestAssured.config().sslConfig(new SSLConfig().relaxedHTTPSValidation()))
+        .body(params.toString())
+        .put(webActionURL)
+    assert(response.statusCode() == expectedCode)
+    response.body.asString shouldBe expectedResult
+  }
+
+  def makeDeleteCallWithExpectedResult(expectedResult: String, expectedCode: Int) = {
+    val response = RestAssured.given().contentType("application/json\r\n").config(RestAssured.config().sslConfig(new SSLConfig().relaxedHTTPSValidation())).delete(webActionURL)
+    assert(response.statusCode() == expectedCode)
+    response.body.asString shouldBe expectedResult
+  }
+
+  behavior of "Message Hub feed web action"
+
+  it should "not be obtainable using the CLI" in {
+      val wsk = new Wsk()
+      implicit val wp = wskprops
+
+      wsk.action.get(webAction, FORBIDDEN)
+  }
+
+  it should "reject post of a trigger due to missing kafka_brokers_sasl argument" in {
+    val params = JsObject(completeParams.fields - "kafka_brokers_sasl")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'kafka_brokers_sasl' parameter.", 400)
+  }
+
+  it should "reject post of a trigger due to missing topic argument" in {
+    val params = JsObject(completeParams.fields - "topic")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'topic' parameter.", 400)
+  }
+
+  it should "reject post of a trigger due to missing triggerName argument" in {
+    val params = JsObject(completeParams.fields - "triggerName")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'triggerName' parameter.", 400)
+  }
+
+  it should "reject post of a trigger due to missing user argument" in {
+    val params = JsObject(completeParams.fields - "user")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'user' parameter to authenticate with Message Hub.", 400)
+  }
+
+  it should "reject post of a trigger due to missing password argument" in {
+    val params = JsObject(completeParams.fields - "password")
+
+    makePutCallWithExpectedResult(params, "You must supply a 'password' parameter to authenticate with Message Hub.", 400)
+  }
+
+  it should "reject put of a trigger when authentication fails" in {
+    makePutCallWithExpectedResult(completeParams, "You are not authorized for this trigger.", 401)
+  }
+
+  // it should "reject delete of a trigger that does not exist" in {
+  //   val expectedJSON = JsObject(
+  //     "triggerName" -> JsString("/invalidNamespace/invalidTrigger"),
+  //     "error" -> JsString("not found")
+  //   )
+  //
+  //   makeDeleteCallWithExpectedResult(expectedJSON, 404)
+  // }
+}


### PR DESCRIPTION
This change introduces redundancy in the feed provider, allowing multiple instances to be deployed simultaneously such that if any one instance stops working, the remaining instances will automatically take over the work of the failed instance.

This is accomplished by changing the feed actions to write directly to the trigger DB, rather than talking directly to the feed provider through REST endpoints. In this way, provider instances become aware of new and deleted triggers by monitoring the DB changes feed. By using the same Kafka group id for every trigger, this ensures that only one provider instance will consume any produced message and therefore, only one will fire the trigger. Additionally, automatic failover and even a bit of load balancing among provider instances is automatically provided by Kafka rebalancing.

As a result, large amounts of code are no longer needed (REST endpoints, safety/security checks, validation, etc.) and have been removed, greatly simplifying the implementation.