### PR TITLE
Test fixes

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -77,8 +77,8 @@ class BasicHealthTest
         val baseTriggerName = "/_/BasicHealthTestTrigger"
 
         val triggerName = System.getProperty("trigger.suffix") match {
-            case suffix if suffix != "" => s"${baseTriggerName}-${suffix}"
-            case _ => baseTriggerName
+            case suffix if suffix != "" && suffix != null => s"${baseTriggerName}-${suffix}"
+            case _ => s"${baseTriggerName}-${currentTime}"
         }
 
         (wp, assetHelper) =>

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -127,7 +127,7 @@ class BasicHealthTest
                     }
 
                 println("Polling for activations")
-                val activations = wsk.activation.pollFor(N = 5, Some(triggerName), since = Some(start), retries = 30)
+                val activations = wsk.activation.pollFor(N = 100, Some(triggerName), since = Some(start), retries = 30)
                 assert(activations.length > 0)
 
                 println("Validating content of activation(s)")

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -155,7 +155,7 @@ class MessageHubFeedTests
       }
 
       println("Polling for activations")
-      val activations = wsk.activation.pollFor(N = 1, Some(triggerName), retries = 60)
+      val activations = wsk.activation.pollFor(N = 100, Some(triggerName), retries = 60)
       assert(activations.length > 0)
 
       val matchingActivations = for {
@@ -215,7 +215,7 @@ class MessageHubFeedTests
 
       // verify there are two trigger activations required to handle these messages
       println("Polling for activations")
-      val activations = wsk.activation.pollFor(N = 2, Some(triggerName), retries = 60)
+      val activations = wsk.activation.pollFor(N = 100, Some(triggerName), retries = 60)
 
       println("Verifying activation content")
       val matchingActivations = for {
@@ -261,7 +261,7 @@ class MessageHubFeedTests
 
       // verify there are no activations that match
       println("Polling for activations")
-      val activations = wsk.activation.pollFor(N = 1, Some(triggerName), retries = 60)
+      val activations = wsk.activation.pollFor(N = 100, Some(triggerName), retries = 60)
 
       println("Verifying activation content")
       val matchingActivations = for {

--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -184,7 +184,7 @@ class MessageHubProduceTests
 
             // verify trigger fired
             println("Polling for activations")
-            val activations = wsk.activation.pollFor(N = 1, Some(triggerName), retries = 60)
+            val activations = wsk.activation.pollFor(N = 100, Some(triggerName), retries = 60)
             assert(activations.length > 0)
 
             val matchingActivations = for {
@@ -244,7 +244,7 @@ class MessageHubProduceTests
 
             // verify trigger fired
             println("Polling for activations")
-            val activations = wsk.activation.pollFor(N = 1, Some(triggerName), retries = 60)
+            val activations = wsk.activation.pollFor(N = 100, Some(triggerName), retries = 60)
             assert(activations.length > 0)
 
             val matchingActivations = for {


### PR DESCRIPTION
Changes are to better avoid cross-contamination for trigger activations during automated tests in the scenario where the kafka instance being used by the tests is shared.

When the kafka instance under test is shared, it could be that messages are being produced to it from other sources. The automated tests should be aware of that and handle, as well as can be expected, to sift through potentially unexpected trigger activations that may result from other uses of the kafka instance.