### PR TITLE
automatically monitor and restore the health of the DB changes feed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
     && ldconfig
 
 RUN pip install gevent==1.1.2 flask==0.11.1 confluent-kafka==0.9.4 \
-        requests==2.10.0 cloudant==2.1.0 psutil==5.0.0
+        requests==2.10.0 cloudant==2.4.0 psutil==5.0.0
 
 # while I expect these will be overridden during deployment, we might as well
 # set reasonable defaults

--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -18,24 +18,28 @@ function main(params) {
         var db;
 
         if (params.__ow_method === "put") {
+            var validatedParams;
             return validateParameters(params)
-                .then(validatedParams => {
+                .then(cleanParams => {
+                    validatedParams = cleanParams;
+
                     console.log(`VALIDATED: ${JSON.stringify(validatedParams, null, 2)}`);
                     db = new Database(params.DB_URL, params.DB_NAME);
 
-                    var promises = [];
-
                     // do these in parallel!
-                    promises.push(db.ensureTriggerIsUnique(validatedParams.triggerName));
-                    promises.push(common.verifyTriggerAuth(validatedParams.triggerURL));
-
-                    return Promise.all(promises)
-                        .then(result => validatedParams);
+                    return Promise.all([
+                        db.ensureTriggerIsUnique(validatedParams.triggerName),
+                        common.verifyTriggerAuth(validatedParams.triggerURL)
+                    ]);
                 })
-                .then(validatedParams => db.recordTrigger(validatedParams))
-                .then(result => {
+                .then(() => db.recordTrigger(validatedParams))
+                .then(() => {
                     console.log('successfully wrote the trigger');
-                    resolve();
+                    resolve({
+                        statusCode: 200,
+                        headers: {'Content-Type': 'text/plain'},
+                        body: validatedParams.uuid
+                    });
                 })
                 .catch(error => {
                     console.log(`Failed to write the trigger ${error}`);

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -95,8 +95,10 @@ function createTrigger(endpoint, params, actionName) {
 
     return request(options)
         .then(response => {
-            // do not pass the response back to the caller, its contents are secret
-            return;
+            console.log(`response ${JSON.stringify(response, null, 2)}`)
+            return {
+                uuid: response
+            };
         })
         .catch(error => {
             console.log(`Error creating trigger: ${JSON.stringify(error, null, 2)}`);

--- a/provider/app.py
+++ b/provider/app.py
@@ -29,6 +29,7 @@ app.debug = False
 
 database = None
 consumers = ConsumerCollection()
+feedService = None
 
 
 @app.route('/')
@@ -38,7 +39,7 @@ def testRoute():
 #TODO call TheDoctor.isAlive() and report on that
 @app.route('/health')
 def healthRoute():
-    return jsonify(generateHealthReport(consumers))
+    return jsonify(generateHealthReport(consumers, feedService.lastCanaryTime))
 
 
 def main():
@@ -77,7 +78,9 @@ def main():
 
     TheDoctor(consumers).start()
 
-    Service(consumers).start()
+    global feedService
+    feedService = Service(consumers)
+    feedService.start()
 
     port = int(os.getenv('PORT', 5000))
     server = WSGIServer(('', port), app, log=logging.getLogger())

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -23,6 +23,7 @@ import time
 from confluent_kafka import Consumer as KafkaConsumer, KafkaError, TopicPartition
 from database import Database
 from datetime import datetime
+from datetimeutils import secondsSince
 from multiprocessing import Process, Manager
 
 local_dev = os.getenv('LOCAL_DEV', 'False')
@@ -102,8 +103,7 @@ class Consumer:
         return self.sharedDictionary['lastPoll']
 
     def secondsSinceLastPoll(self):
-        lastPollDelta = datetime.now() - self.lastPoll()
-        return lastPollDelta.total_seconds()
+        return secondsSince(self.lastPoll())
 
 
 class ConsumerProcess (Process):
@@ -192,8 +192,7 @@ class ConsumerProcess (Process):
         self.sharedDictionary['lastPoll'] = datetime.now()
 
     def secondsSinceLastPoll(self):
-        lastPollDelta = datetime.now() - self.lastPoll()
-        return lastPollDelta.total_seconds()
+        return secondsSince(self.lastPoll())
 
     def run(self):
         try:

--- a/provider/datetimeutils.py
+++ b/provider/datetimeutils.py
@@ -1,0 +1,19 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+
+def secondsSince(someDateTime):
+    delta = datetime.now() - someDateTime
+    return delta.total_seconds()

--- a/provider/health.py
+++ b/provider/health.py
@@ -15,6 +15,7 @@
 import psutil   # https://pythonhosted.org/psutil/
 
 from datetime import datetime
+from datetimeutils import secondsSince
 
 MILLISECONDS_IN_SECOND = 1000
 MEGABYTE = 10 ** 6
@@ -132,8 +133,9 @@ def getConsumers(consumers):
 
     return consumerReports
 
-def generateHealthReport(consumers):
+def generateHealthReport(consumers, lastCanaryTime):
     healthReport = {}
+    healthReport['last_db_canary'] = secondsSince(lastCanaryTime)
     healthReport['uptime'] = getUpdateTime()
     healthReport['cpu_times'] = getCPUTimes()
     healthReport['cpu_percent'] = getCPUPercent()

--- a/provider/service.py
+++ b/provider/service.py
@@ -110,6 +110,8 @@ class Service (Thread):
                 if secondsSince(self.lastCanaryTime) > canaryTimeout:
                     logging.warn('[canary] It has been more than {} seconds since the last canary - restarting the DB changes feed'.format(canaryTimeout))
                     self.restartChangesFeed()
+                    # break out of the for loop so that it can be re-established
+                    # with the new changes feed.
                     break
 
             logging.debug("[changes] I made it out of the changes loop!")


### PR DESCRIPTION
Resolves #185 

The idea here is to periodically create non-trigger "canary" documents into the DB. The changes feed Service will monitor the time that the last canary was detected by the changes feed, and if the time exceeds a specified limit, it will automatically re-initialize the changes feed.

Additionally, I added a health test to ensure that new triggers could be successfully created. This required that the feed action return the UUID of the created trigger, so that it could be verified by the test through the `/health` endpoint.