### PR TITLE
Add ASF license to python files; no line limit changes.

### DIFF
--- a/action/kafkaProduce.py
+++ b/action/kafkaProduce.py
@@ -1,7 +1,28 @@
+"""Kafka message producer.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 import ssl
 import base64
 from kafka import KafkaProducer
 from kafka.errors import NoBrokersAvailable
+
 
 def main(params):
     validationResult = validateParams(params)
@@ -36,6 +57,7 @@ def main(params):
         return {'error': '{}'.format(e)}
 
     return {"success": True}
+
 
 def validateParams(params):
     validatedParams = params.copy()

--- a/action/messageHubProduce.py
+++ b/action/messageHubProduce.py
@@ -1,7 +1,28 @@
+"""MessageHub producer.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 import ssl
 import base64
 from kafka import KafkaProducer
 from kafka.errors import NoBrokersAvailable
+
 
 def main(params):
     validationResult = validateParams(params)
@@ -47,6 +68,7 @@ def main(params):
         return {'error': '{}'.format(e)}
 
     return {"success": True}
+
 
 def validateParams(params):
     validatedParams = params.copy()

--- a/provider/app.py
+++ b/provider/app.py
@@ -1,16 +1,22 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Flask application.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 
 import logging
 import os
@@ -36,7 +42,8 @@ feedService = None
 def testRoute():
     return jsonify('Hi!')
 
-#TODO call TheDoctor.isAlive() and report on that
+
+# TODO call TheDoctor.isAlive() and report on that
 @app.route('/health')
 def healthRoute():
     return jsonify(generateHealthReport(consumers, feedService.lastCanaryTime))

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -1,16 +1,22 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Consumer class.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 
 import json
 import logging
@@ -31,6 +37,7 @@ payload_limit = int(os.getenv('PAYLOAD_LIMIT', 900000))
 check_ssl = (local_dev == 'False')
 
 processingManager = Manager()
+
 
 # Each Consumer instance will have a shared dictionary that will be used to
 # indicate state, and desired state changes between this process, and the ConsumerProcess.

--- a/provider/consumercollection.py
+++ b/provider/consumercollection.py
@@ -1,3 +1,23 @@
+"""ConsumerCollection class.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 from threading import Lock
 
 # basically a thread safe wrapper around dict

--- a/provider/database.py
+++ b/provider/database.py
@@ -1,25 +1,31 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Database class.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 
 import logging
 import os
 import time
-import uuid
 
 from cloudant.client import CouchDB
 from cloudant.result import Result
 from datetime import datetime
+
 
 class Database:
     db_prefix = os.getenv('DB_PREFIX', '')
@@ -67,8 +73,7 @@ class Database:
         except Exception as e:
             logging.error('[{}] Uncaught exception while disabling trigger: {}'.format(triggerFQN, e))
 
-
-    def changesFeed(self, timeout, since = None):
+    def changesFeed(self, timeout, since=None):
         if since == None:
             return self.database.infinite_changes(include_docs=True, heartbeat=(timeout*1000))
         else:
@@ -125,7 +130,7 @@ class Database:
                                 }"""
                     }
                 }
-            });
+            })
         else:
             logging.info("design doc already exists")
 

--- a/provider/datetimeutils.py
+++ b/provider/datetimeutils.py
@@ -1,18 +1,25 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""datetime utilities.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 
 from datetime import datetime
+
 
 def secondsSince(someDateTime):
     delta = datetime.now() - someDateTime

--- a/provider/health.py
+++ b/provider/health.py
@@ -1,18 +1,25 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Health reporter.
 
-import psutil   # https://pythonhosted.org/psutil/
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+# https://pythonhosted.org/psutil/
+import psutil
 
 from datetime import datetime
 from datetimeutils import secondsSince
@@ -21,6 +28,7 @@ MILLISECONDS_IN_SECOND = 1000
 MEGABYTE = 10 ** 6
 START_TIME = datetime.now()
 CPU_INTERVAL = 0.5
+
 
 def getSwapMemory():
     total, used, free, percent, sin, sout = psutil.swap_memory()
@@ -33,6 +41,7 @@ def getSwapMemory():
     swap_memory['sout'] = '%d MB' % (sout / MEGABYTE)
 
     return swap_memory
+
 
 def getVirtualMemory():
     total, available, percent, used, free, active, inactive, buffers, cached, shared = psutil.virtual_memory()
@@ -50,6 +59,7 @@ def getVirtualMemory():
 
     return virtual_memory
 
+
 def getCPUTimes():
     user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice = psutil.cpu_times()
     cpu_times = {}
@@ -66,8 +76,10 @@ def getCPUTimes():
 
     return cpu_times
 
+
 def getCPUPercent():
     return '%d%%' % psutil.cpu_percent(interval=CPU_INTERVAL)
+
 
 def getDiskUsage():
     total, used, free, percent = psutil.disk_usage('/')
@@ -78,6 +90,7 @@ def getDiskUsage():
     disk_usage['percent'] = '%d MB' % (percent / MEGABYTE)
 
     return disk_usage
+
 
 def getDiskIOCounters():
     read_count, write_count, read_bytes, write_bytes, read_time, write_time, read_merged_count, write_merged_count,\
@@ -109,12 +122,14 @@ def getNetworkIOCounters():
 
     return net_io_counters
 
+
 def getUpdateTime():
     currentTime = datetime.now()
     delta = currentTime - START_TIME
     uptimeSeconds = int(round(delta.total_seconds()))
 
     return '%d seconds' % uptimeSeconds
+
 
 def getConsumers(consumers):
     consumerReports = []
@@ -132,6 +147,7 @@ def getConsumers(consumers):
         consumerReports.append(consumerInfo)
 
     return consumerReports
+
 
 def generateHealthReport(consumers, lastCanaryTime):
     healthReport = {}

--- a/provider/service.py
+++ b/provider/service.py
@@ -1,16 +1,22 @@
-# Copyright 2016 IBM Corp. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Service class, CanaryDocumentGenerator class.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 
 import logging
 import time
@@ -22,16 +28,17 @@ from datetimeutils import secondsSince
 from threading import Thread
 
 # How often to produce canary documents
-canaryInterval = 60 # seconds
+canaryInterval = 60  # seconds
 
 # How long to wait between detecting carnary documents before restarting the
 # DB changes feed. Should be significantly larger than canaryInterval to allow for
 # the roundtrip to DB as well as to let the Service handle other work in the
 # meantime.
-canaryTimeout = 90 # seconds
+canaryTimeout = 90  # seconds
 
 # How long the changes feed should poll before timing out
-changesFeedTimeout = 10 # seconds
+changesFeedTimeout = 10  # seconds
+
 
 class Service (Thread):
     def __init__(self, consumers):
@@ -142,6 +149,7 @@ class Service (Thread):
 
     def __isTriggerDocActive(self, doc):
         return ('status' not in doc or doc['status']['active'] == True)
+
 
 class CanaryDocumentGenerator (Thread):
     def __init__(self):

--- a/provider/thedoctor.py
+++ b/provider/thedoctor.py
@@ -1,8 +1,29 @@
+"""TheDoctor class.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 import logging
 import time
 
 from consumer import Consumer
 from threading import Thread
+
 
 class TheDoctor (Thread):
     # maximum time to allow a consumer to not successfully poll() before restarting


### PR DESCRIPTION
This PR seeks to replace PR https://github.com/apache/incubator-openwhisk-package-kafka/pull/149 with only addition of ASF headers and a small number of spacing issues.  No 79 char line limits changes included.

Any previous changes to account for proper use of "is, is not" for use with built-in constants True, False and None are removed.  However, we should look to fix these where possible as these may be more performant and perform the correct boolean comparison that was intended.

In addition, I did not attempt to adjust string literals to have single quotes and have translatable strings have double quotes.