### PR TITLE
Use one canary document per provider instance

### DIFF
--- a/provider/database.py
+++ b/provider/database.py
@@ -83,32 +83,36 @@ class Database:
         maxRetries = 3
         retryCount = 0
 
+        instance = os.getenv('INSTANCE', 'messageHubTrigger-0')
+        canaryId = "canary-{}".format(instance)
+
         while retryCount < maxRetries:
             try:
-                document = dict()
-                document['canary'] = datetime.now().isoformat()
+                if canaryId in self.database.keys(remote=True):
+                    # update the timestamp to cause a document change
+                    logging.debug("[database] Canary doc exists, updating it.")
 
-                result = self.database.create_document(document)
-                logging.info('[canary] Successfully wrote canary to DB')
+                    myCanaryDocument = self.database[canaryId]
+                    myCanaryDocument["canary-timestamp"] = datetime.now().isoformat()
+                    myCanaryDocument.save()
 
-                return result
+                    return
+                else:
+                    logging.debug("[database] Canary doc does not exist, creating it.")
+                    document = dict()
+                    document['_id'] = canaryId
+                    document['canary-timestamp'] = datetime.now().isoformat()
+
+                    result = self.database.create_document(document)
+                    logging.debug('[canary] Successfully wrote canary to DB')
+
+                    return
             except Exception as e:
                 retryCount += 1
-                logging.error('[canary] Uncaught exception while recording trigger to database: {}'.format(e))
+                logging.error(
+                    '[canary] Uncaught exception while writing canary document: {}'.format(e))
 
         logging.error('[canary] Retried and failed {} times to create a canary'.format(maxRetries))
-
-    def deleteDoc(self, docId):
-        try:
-            document = self.database[docId]
-
-            if document.exists():
-                document.delete()
-                logging.debug('[database] Successfully deleted document from DB: {}'.format(docId))
-            else:
-                logging.warn('[database] Attempted to delete non-existent document from DB: {}'.format(docId))
-        except Exception as e:
-            logging.error('[database] Uncaught exception while deleting document {} from database: {}'.format(docId, e))
 
     def migrate(self):
         logging.info('Starting DB migration')

--- a/provider/service.py
+++ b/provider/service.py
@@ -104,13 +104,10 @@ class Service (Thread):
                                 existingConsumer.disable()
                             else:
                                 logging.debug('[changes] Found non-interesting trigger change: \n{}\n{}'.format(existingConsumer.desiredState(), document))
-                    elif 'canary' in change['doc']:
+                    elif 'canary-timestamp' in change['doc']:
                         # found a canary - update lastCanaryTime
                         logging.info('[canary] I found a canary. The last one was {} seconds ago.'.format(secondsSince(self.lastCanaryTime)))
                         self.lastCanaryTime = datetime.now()
-
-                        # delete the canary document
-                        self.database.deleteDoc(change['id'])
                     else:
                         logging.debug('[changes] Found a change for a non-trigger document')
 


### PR DESCRIPTION
This eliminates canary document deletes, which is good news for the changes feed as it won't have to process all the deletes when the container starts. This also avoids the problem of getting a 404 while trying to delete a canary that was already deleted by another instance.

Resolves #189 