### PR TITLE
Do not attempt to share DB connections across multiple processes

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -118,8 +118,6 @@ class ConsumerProcess (Process):
     retry_timeout = 1   # Timeout in seconds
     max_retries = 10    # Maximum number of times to retry firing trigger
 
-    database = Database()
-
     def __init__(self, trigger, params, sharedDictionary):
         Process.__init__(self)
 
@@ -160,6 +158,8 @@ class ConsumerProcess (Process):
             self.encodeKeyAsBase64 = params["isBinaryKey"]
         else:
             self.encodeKeyAsBase64 = False
+
+        self.database = Database()
 
         # always init consumer to None in case the consumer needs to shut down
         # before the KafkaConsumer is fully initialized/assigned

--- a/provider/database.py
+++ b/provider/database.py
@@ -35,21 +35,22 @@ class Database:
     password = os.environ['DB_PASS']
     url = os.environ['DB_URL']
 
-    client = CouchDB(username, password, url=url)
-    client.connect()
-
     filters_design_doc_id = '_design/filters'
     only_triggers_view_id = 'only-triggers'
 
     instance = os.getenv('INSTANCE', 'messageHubTrigger-0')
     canaryId = "canary-{}".format(instance)
 
-    if dbname in client.all_dbs():
-        logging.info('Database exists - connecting to it.')
-        database = client[dbname]
-    else:
-        logging.warn('Database does not exist - creating it.')
-        database = client.create_database(dbname)
+    def __init__(self):
+        client = CouchDB(self.username, self.password, url=self.url)
+        client.connect()
+
+        if self.dbname in client.all_dbs():
+            logging.info('Database exists - connecting to it.')
+            self.database = client[self.dbname]
+        else:
+            logging.warn('Database does not exist - creating it.')
+            self.database = client.create_database(self.dbname)
 
 
     def disableTrigger(self, triggerFQN, status_code):


### PR DESCRIPTION
The problem is that keeping the DB connection as a class property causes it to be re-used, potentially between multiple processes. For SSL connections in Python, this is not supported.

The fix is to ensure that the DB connection is made an instance field of the Database class, and also to ensure that all Database instances are themselves instance fields of their respective classes. This avoids sharing trying to share the same connection between multiple Python processes.