### PR TITLE
Add a 1 second delay between test retries

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -100,7 +100,7 @@ class BasicHealthTest
                     retry({
                         val response = RestAssured.given().get(System.getProperty("health_url"))
                         assert(response.statusCode() == 200 && response.asString().contains(uuid))
-                    }, N = 3)
+                    }, N = 3, waitBeforeRetry = Some(1.second))
             }
     }
 


### PR DESCRIPTION
After creating a trigger, there may be some time before the service is aware of the new trigger. Add a 1 second delay to the retry attempts at verifying the trigger was created.