### PR TITLE
Block until message is sent, or timeout

### DIFF
--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -120,7 +120,7 @@ class MessageHubProduceTests
         withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", badBrokerParams)) {
             activation =>
                 activation.response.success shouldBe false
-                activation.response.result.get.toString should include("No brokers available")
+                activation.response.result.get.toString should include("Timed out communicating with Message Hub")
         }
     }
 


### PR DESCRIPTION
As it turns out, `flush()` only waits for the message to be put on the network, and does not wait for any required acks.