### PR TITLE
exponential backoff on trigger fire retry

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -114,9 +114,7 @@ class Consumer:
 
 
 class ConsumerProcess (Process):
-
-    retry_timeout = 1   # Timeout in seconds
-    max_retries = 10    # Maximum number of times to retry firing trigger
+    max_retries = 6    # Maximum number of times to retry firing trigger
 
     def __init__(self, trigger, params, sharedDictionary):
         Process.__init__(self)
@@ -371,10 +369,10 @@ class ConsumerProcess (Process):
                 if retry:
                     retry_count += 1
 
-                    if retry_count < self.max_retries:
-                        logging.info("[{}] Retrying in {} second(s)".format(
-                            self.trigger, self.retry_timeout))
-                        time.sleep(self.retry_timeout)
+                    if retry_count <= self.max_retries:
+                        sleepyTime = pow(2,retry_count)
+                        logging.info("[{}] Retrying in {} second(s)".format(self.trigger, sleepyTime))
+                        time.sleep(sleepyTime)
                     else:
                         logging.warn("[{}] Skipping {} messages to offset {} of partition {}".format(self.trigger, len(messages), lastMessage.offset(), lastMessage.partition()))
                         self.consumer.commit(offsets=self.__getOffsetList(messages), async=False)

--- a/provider/thedoctor.py
+++ b/provider/thedoctor.py
@@ -27,7 +27,8 @@ from threading import Thread
 
 class TheDoctor (Thread):
     # maximum time to allow a consumer to not successfully poll() before restarting
-    poll_timeout_seconds = 20
+    # this value must be greater than the total amount of time a consumer might retry firing a trigger
+    poll_timeout_seconds = 200
 
     # interval between the Doctor making rounds
     sleepy_time_seconds = 2


### PR DESCRIPTION
Resolves #207 

With this algorithm, there are 6 retry attempts with a delay of `2^x` seconds between attempts. This has the following effects:
- Retries initially happen quickly
- Total possible retry length (from first failure to last attempt) is extended to 126 seconds
- The last retry delay is 64 seconds which will ensure that the 60 second rolling throttle window has passed between the last two attempts