### PR TITLE
Replace 'kafka_brokers_sasl' with the (correct) 'brokers'

### DIFF
--- a/action/kafkaProduce.py
+++ b/action/kafkaProduce.py
@@ -195,7 +195,7 @@ def getProducer(validatedParams, timeout_ms):
 
 def getConnectionHash(params):
     # always use the sorted brokers to combat the effects of shuffle()
-    brokers = params['kafka_brokers_sasl']
+    brokers = params['brokers']
     brokers.sort()
     brokersString = ",".join(brokers)
 


### PR DESCRIPTION
`kafka_brokers_sasl` is only valid in the messageHubProduce action. The equivalent parameter for kafkaProduce is just `brokers`

Resolves #211 