### PR TITLE
Prevent infinite exception loop in Service thread

### DIFF
--- a/provider/database.py
+++ b/provider/database.py
@@ -53,8 +53,9 @@ class Database:
             self.database = self.client.create_database(self.dbname)
 
     def destroy(self):
-        self.client.disconnect()
-        self.client = None
+        if self.client is not None:
+            self.client.disconnect()
+            self.client = None
 
     def disableTrigger(self, triggerFQN, status_code):
         try:


### PR DESCRIPTION
Prevents infinite loop that occurs when trying to disconnect the client when the client does not exist.

```
September 9th 2017, 00:05:00.720	[2017-09-08T23:33:04.225Z] [INFO] [??] [kafkatriggers] Shutting down existing DB client	messagehubtrigger-worker00

	September 9th 2017, 00:05:00.480	[2017-09-08T23:33:04.217Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:05:00.433	[2017-09-08T23:33:16.493Z] [INFO] [??] [kafkatriggers] Shutting down existing DB client	messagehubtrigger-worker01

	September 9th 2017, 00:05:00.359	[2017-09-08T23:33:04.214Z] [INFO] [??] [kafkatriggers] Shutting down existing DB client	messagehubtrigger-worker00

	September 9th 2017, 00:05:00.239	[2017-09-08T23:33:04.210Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.998	[2017-09-08T23:33:04.202Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.944	[2017-09-08T23:33:16.478Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker01

	September 9th 2017, 00:04:59.944	[2017-09-08T23:33:16.478Z] [ERROR] [??] [kafkatriggers] [canary] Exception caught from changes feed. Restarting changes feed...	messagehubtrigger-worker01

	September 9th 2017, 00:04:59.638	[2017-09-08T23:33:04.190Z] [INFO] [??] [kafkatriggers] Shutting down existing DB client	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.494	[2017-09-08T23:33:04.188Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.493	[2017-09-08T23:33:04.188Z] [INFO] [??] [kafkatriggers] Shutting down existing DB client	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.374	[2017-09-08T23:33:04.184Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.371	[2017-09-08T23:33:04.182Z] [ERROR] [??] [kafkatriggers] 'NoneType' object has no attribute 'disconnect'	messagehubtrigger-worker00

	September 9th 2017, 00:04:59.249	[2017-09-08T23:33:04.178Z] [ERROR] [??] [kafkatriggers] [canary] Exception caught from changes feed. Restarting changes feed...	messagehubtrigger-worker00

```