### PR TITLE
add parameters as query parameters for get request

### DIFF
--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -136,9 +136,8 @@ function getTrigger(endpoint, params, actionName) {
         url: getWebActionURL(endpoint, actionName),
         rejectUnauthorized: false,
         json: true,
-        body: params,
+        qs: params,
         headers: {
-            'Content-Type': 'application/json',
             'Accept': 'application/json',
             'User-Agent': 'whisk'
         }


### PR DESCRIPTION
fix for `trigger get` failing in production because of executing a get request with a body