### PR TITLE
Add rule and action to trigger tests which rely upon activation records

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -29,14 +29,14 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpec, Inside, Matchers}
 import org.scalatest.junit.JUnitRunner
 import common.JsHelpers
 import common.TestHelpers
-import common.Wsk
-import common.WskActorSystem
-import common.WskProps
-import common.WskTestHelpers
 import common.TestUtils
 import common.TestUtils.DONTCARE_EXIT
 import common.TestUtils.NOT_FOUND
 import common.TestUtils.SUCCESS_EXIT
+import common.Wsk
+import common.WskActorSystem
+import common.WskProps
+import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsObject, pimpAny}
 import com.jayway.restassured.RestAssured

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -27,15 +27,10 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Inside, Matchers}
 import org.scalatest.junit.JUnitRunner
-import common.JsHelpers
-import common.TestHelpers
+import common._
 import common.TestUtils.DONTCARE_EXIT
 import common.TestUtils.NOT_FOUND
 import common.TestUtils.SUCCESS_EXIT
-import common.Wsk
-import common.WskActorSystem
-import common.WskProps
-import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsObject, pimpAny}
 import com.jayway.restassured.RestAssured
@@ -141,6 +136,16 @@ class BasicHealthTest
       } else {
         result.exitCode shouldBe (SUCCESS_EXIT)
         println(s"Trigger already exists, reusing it: $triggerName")
+      }
+
+      val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+      val defaultActionName = "hello"
+
+      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = defaultActionName)
       }
 
       retry({

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -27,7 +27,13 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Inside, Matchers}
 import org.scalatest.junit.JUnitRunner
-import common._
+import common.JsHelpers
+import common.TestHelpers
+import common.Wsk
+import common.WskActorSystem
+import common.WskProps
+import common.WskTestHelpers
+import common.TestUtils
 import common.TestUtils.DONTCARE_EXIT
 import common.TestUtils.NOT_FOUND
 import common.TestUtils.SUCCESS_EXIT

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -147,7 +147,7 @@ class BasicHealthTest
       val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
       val defaultActionName = "hello"
 
-      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+      assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
         action.create(name, defaultAction)
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -137,7 +137,7 @@ class MessageHubFeedTests
         "isBinaryKey" -> true.toJson,
         "isBinaryValue" -> true.toJson))
 
-      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+      assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
         action.create(name, defaultAction)
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
@@ -208,7 +208,7 @@ class MessageHubFeedTests
         "isBinaryKey" -> false.toJson,
         "isBinaryValue" -> false.toJson))
 
-      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+      assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
         action.create(name, defaultAction)
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
@@ -265,7 +265,7 @@ class MessageHubFeedTests
         "isBinaryKey" -> false.toJson,
         "isBinaryValue" -> false.toJson))
 
-      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+      assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
         action.create(name, defaultAction)
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
@@ -385,7 +385,7 @@ class MessageHubFeedTests
         "topic" -> topic.toJson
       ))
 
-      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+      assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
         action.create(name, defaultAction)
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -29,12 +29,7 @@ import org.scalatest.Inside
 import org.scalatest.junit.JUnitRunner
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import common.JsHelpers
-import common.TestHelpers
-import common.Wsk
-import common.WskActorSystem
-import common.WskProps
-import common.WskTestHelpers
+import common._
 import ActionHelper._
 import java.util.Base64
 import java.nio.charset.StandardCharsets
@@ -66,6 +61,9 @@ class MessageHubFeedTests
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
   val actionName = s"${messagingPackage}/${messageHubFeed}"
+
+  val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+  val defaultActionName = "hello"
 
   behavior of "Message Hub feed action"
 
@@ -133,6 +131,13 @@ class MessageHubFeedTests
         "isBinaryKey" -> true.toJson,
         "isBinaryValue" -> true.toJson))
 
+      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = defaultActionName)
+      }
+
       // It takes a moment for the consumer to fully initialize.
       println("Giving the consumer a moment to get ready")
       Thread.sleep(consumerInitTime)
@@ -197,6 +202,13 @@ class MessageHubFeedTests
         "isBinaryKey" -> false.toJson,
         "isBinaryValue" -> false.toJson))
 
+      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = defaultActionName)
+      }
+
       // It takes a moment for the consumer to fully initialize.
       println("Giving the consumer a moment to get ready")
       Thread.sleep(consumerInitTime)
@@ -247,6 +259,13 @@ class MessageHubFeedTests
         "isBinaryKey" -> false.toJson,
         "isBinaryValue" -> false.toJson))
 
+      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = defaultActionName)
+      }
+
       // It takes a moment for the consumer to fully initialize.
       println("Giving the consumer a moment to get ready")
       Thread.sleep(consumerInitTime)
@@ -293,6 +312,17 @@ class MessageHubFeedTests
         "isBinaryKey" -> false.toJson,
         "isBinaryValue" -> false.toJson
       ))
+
+      val run = wsk.action.invoke(actionName, parameters = Map(
+        "triggerName" -> triggerName.toJson,
+        "lifecycleEvent" -> "UPDATE".toJson,
+        "authKey" -> wp.authKey.toJson
+      ))
+
+      withActivation(wsk.activation, run) {
+        activation =>
+          activation.response.success shouldBe false
+      }
   }
 
   it should "reject trigger update when both isJSONData and isBinaryValue are enabled" in withAssetCleaner(wskprops) {
@@ -348,6 +378,13 @@ class MessageHubFeedTests
         "kafka_brokers_sasl" -> kafkaUtils.getAsJson("brokers"),
         "topic" -> topic.toJson
       ))
+
+      assetHelper.withCleaner(wsk.action, "hello") { (action, name) =>
+        action.create(name, defaultAction)
+      }
+      assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+        rule.create(name, trigger = triggerName, action = defaultActionName)
+      }
 
       println("Giving the consumer a moment to get ready")
       Thread.sleep(consumerInitTime)

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -29,7 +29,13 @@ import org.scalatest.Inside
 import org.scalatest.junit.JUnitRunner
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import common._
+import common.JsHelpers
+import common.TestUtils
+import common.TestHelpers
+import common.Wsk
+import common.WskActorSystem
+import common.WskProps
+import common.WskTestHelpers
 import ActionHelper._
 import java.util.Base64
 import java.nio.charset.StandardCharsets

--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -30,6 +30,7 @@ import org.scalatest.junit.JUnitRunner
 
 import common.JsHelpers
 import common.TestHelpers
+import common.TestUtils
 import common.Wsk
 import common.WskActorSystem
 import common.WskProps
@@ -63,6 +64,9 @@ class MessageHubProduceTests
     val consumerInitTime = 10000 // ms
 
     val kafkaUtils = new KafkaUtils
+
+    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
+    val defaultActionName = "hello"
 
     // these parameter values are 100% valid and should work as-is
     val validParameters = Map(
@@ -169,6 +173,13 @@ class MessageHubProduceTests
                     activation.response.success shouldBe true
             }
 
+            assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
+                action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+                rule.create(name, trigger = triggerName, action = defaultActionName)
+            }
+
             // It takes a moment for the consumer to fully initialize.
             println("Giving the consumer a moment to get ready")
             Thread.sleep(consumerInitTime)
@@ -227,6 +238,13 @@ class MessageHubProduceTests
                 activation =>
                     // should be successful
                     activation.response.success shouldBe true
+            }
+
+            assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
+                action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
+                rule.create(name, trigger = triggerName, action = defaultActionName)
             }
 
             // It takes a moment for the consumer to fully initialize.


### PR DESCRIPTION
In order to support the removal of activation records for any trigger fires not attached to a rule, the tests which rely upon the presence of trigger activation records have been updated to create a simple hello action and a rule