### PR TITLE
deprecate messageHubProduce and kafkaProduce actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ $ wsk trigger update myTopicTrigger -p isJSONData false -p isBinaryKey true -p i
 ```
 
 ### Producing messages to Message Hub
+
+The `/messaging/messageHubProduce` Action is deprecated and will be removed at a future date. To maintain optimal performance, migrate your usage of the `/messaging/messageHubProduce` Action to use a persistent connection when data is produced to Message Hub.
+
 If you would like to use an OpenWhisk action to conveniently produce a message to Message Hub, you can use the `/messaging/messageHubProduce` action. This action takes the following parameters:
 
 |Name|Type|Description|
@@ -327,6 +330,9 @@ wsk action invoke /messaging/messageHubProduce -p kafka_brokers_sasl "[\"kafka01
 ```
 
 ### Producing messages to a generic Kafka instance
+
+The `/messaging/kafkaProduce` Action is deprecated and will be removed at a future date. To maintain optimal performance, migrate your usage of the `/messaging/kafkaProduce` Action to use a persistent connection when data is produced to Kafka.
+
 If you would like to use an OpenWhisk action to conveniently produce a message to a generic Kafka instance, you can use the `/messaging/kafkaProduce` action. This action takes the following parameters:
 
 |Name|Type|Description|

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -107,7 +107,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/mes
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/messageHubProduce "$PACKAGE_HOME/action/messageHubProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
-    -a deprecated true
+    -a deprecated true \
     -a description 'Deprecated - Produce a message to Message Hub' \
     -a parameters '[ {"name":"kafka_brokers_sasl", "required":true, "description": "Array of Message Hub brokers"},{"name":"user", "required":true, "description": "Message Hub username"},{"name":"password", "required":true, "description": "Message Hub password", "type":"password"},{"name":"topic", "required":true, "description": "Topic that you wish to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"kafka_brokers_sasl":"[\"kafka01-prod01.messagehub.services.us-south.bluemix.net:9093\"]", "username":"someUsername", "password":"somePassword", "topic":"mytopic", "value": "This is my message"}'

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -107,6 +107,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/mes
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/messageHubProduce "$PACKAGE_HOME/action/messageHubProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
+    -a deprecated true
     -a description 'Deprecated - Produce a message to Message Hub' \
     -a parameters '[ {"name":"kafka_brokers_sasl", "required":true, "description": "Array of Message Hub brokers"},{"name":"user", "required":true, "description": "Message Hub username"},{"name":"password", "required":true, "description": "Message Hub password", "type":"password"},{"name":"topic", "required":true, "description": "Topic that you wish to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"kafka_brokers_sasl":"[\"kafka01-prod01.messagehub.services.us-south.bluemix.net:9093\"]", "username":"someUsername", "password":"somePassword", "topic":"mytopic", "value": "This is my message"}'

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -107,6 +107,6 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/mes
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/messageHubProduce "$PACKAGE_HOME/action/messageHubProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
-    -a description 'Produce a message to Message Hub' \
+    -a description 'Deprecated - Produce a message to Message Hub' \
     -a parameters '[ {"name":"kafka_brokers_sasl", "required":true, "description": "Array of Message Hub brokers"},{"name":"user", "required":true, "description": "Message Hub username"},{"name":"password", "required":true, "description": "Message Hub password", "type":"password"},{"name":"topic", "required":true, "description": "Topic that you wish to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"kafka_brokers_sasl":"[\"kafka01-prod01.messagehub.services.us-south.bluemix.net:9093\"]", "username":"someUsername", "password":"somePassword", "topic":"mytopic", "value": "This is my message"}'

--- a/installKafka.sh
+++ b/installKafka.sh
@@ -108,6 +108,6 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/kaf
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/kafkaProduce "$PACKAGE_HOME/action/kafkaProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
-    -a description 'Produce a message to a Kafka cluster' \
+    -a description 'Deprecated - Produce a message to a Kafka cluster' \
     -a parameters '[ {"name":"brokers", "required":true, "description": "Array of Kafka brokers"},{"name":"topic", "required":true, "description": "Topic that you want to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"brokers":"[\"127.0.0.1:9093\"]", "topic":"mytopic", "value": "This is my message"}'

--- a/installKafka.sh
+++ b/installKafka.sh
@@ -108,6 +108,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/kaf
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/kafkaProduce "$PACKAGE_HOME/action/kafkaProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
+    -a deprecated true
     -a description 'Deprecated - Produce a message to a Kafka cluster' \
     -a parameters '[ {"name":"brokers", "required":true, "description": "Array of Kafka brokers"},{"name":"topic", "required":true, "description": "Topic that you want to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"brokers":"[\"127.0.0.1:9093\"]", "topic":"mytopic", "value": "This is my message"}'

--- a/installKafka.sh
+++ b/installKafka.sh
@@ -108,7 +108,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 messagingWeb/kaf
 $WSK_CLI -i --apihost "$EDGEHOST" action update messaging/kafkaProduce "$PACKAGE_HOME/action/kafkaProduce.py" \
     --auth "$AUTH" \
     --kind python:3 \
-    -a deprecated true
+    -a deprecated true \
     -a description 'Deprecated - Produce a message to a Kafka cluster' \
     -a parameters '[ {"name":"brokers", "required":true, "description": "Array of Kafka brokers"},{"name":"topic", "required":true, "description": "Topic that you want to produce a message to"},{"name":"value", "required":true, "description": "The value for the message you want to produce"},{"name":"key", "required":false, "description": "The key for the message you want to produce"},{"name":"base64DecodeValue", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the value parameter"},{"name":"base64DecodeKey", "required":false, "description": "If true, the message will be produced with a Base64 decoded version of the key parameter"}]' \
     -a sampleInput '{"brokers":"[\"127.0.0.1:9093\"]", "topic":"mytopic", "value": "This is my message"}'


### PR DESCRIPTION
Deprecate the `messageHubProduce` and `kafkaProduce` actions. They are inadequate in terms of performance. These actions create too many short lived connections to a kafka/message hub cluster which does not offer the benefit of a single long lived connection which can produce many more messages in a more efficient manner. 