### PR TITLE
Verify trigger fire by sideeffect.

### DIFF
--- a/tests/dat/createTriggerActions.js
+++ b/tests/dat/createTriggerActions.js
@@ -1,0 +1,11 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+var openwhisk = require('openwhisk');
+
+function main(params) {
+    console.log(JSON.stringify(params));
+    var name = params.messages[0].value;
+    var ow = openwhisk();
+    return ow.triggers.create({name: name});
+}


### PR DESCRIPTION
Until now, we verify the kafkaprovider, by looking if the action in OpenWhisk has been executed with `activation list`. The problem with this call is, that the activation may not be in the list in time, because it only returns the result of an CouchDB view. If there is much load on the database, the view-computation may be behind and not return the activation.
As side effect, we use a trigger creation. The name of the trigger will be read from the kafka message. All other things (like credentials, ...) are already present in the action, that is invoked anyway.
To check if the trigger exists, we use the ID of the trigger. So no view is involved anymore.