### PR TITLE
Ignore certificates on creating a trigger within the side-effect action.

### DIFF
--- a/tests/dat/createTriggerActions.js
+++ b/tests/dat/createTriggerActions.js
@@ -6,6 +6,6 @@ var openwhisk = require('openwhisk');
 function main(params) {
     console.log(JSON.stringify(params));
     var name = params.messages[0].value;
-    var ow = openwhisk();
+    var ow = openwhisk({ignore_certs: true});
     return ow.triggers.create({name: name});
 }


### PR DESCRIPTION
If the test to create an entity as side-effect within the triggered action runs in an environment with self signed certificates, this test will fail.

This PR fixes this bug.

@abaruni Could you please have a look on this PR?