### PR TITLE
Remove encoding check

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -450,13 +450,6 @@ class ConsumerProcess (Process):
         return offsets
 
     def __encodeMessageIfNeeded(self, value):
-        # let's make sure whatever data we're getting is utf-8 encoded
-        try:
-            value = value.encode('utf-8')
-        except UnicodeDecodeError:
-            logging.warn('[{}] Value contains non-unicode bytes. Replacing invalid bytes.'.format(self.trigger))
-            value = unicode(value, errors='replace').encode('utf-8')
-
         if self.encodeValueAsJSON:
             try:
                 parsed = json.loads(value)

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -458,7 +458,6 @@ class ConsumerProcess (Process):
             except ValueError:
                 # no big deal, just return the original value
                 logging.warn('[{}] I was asked to encode a message as JSON, but I failed.'.format(self.trigger))
-                value = "\"{}\"".format(value)
                 pass
         elif self.encodeValueAsBase64:
             try:


### PR DESCRIPTION
The data coming from kafka is already utf-8 encoded. it appears as though the encoding check via `encode` is rejecting valid characters. a similar rejection of valid characters is happening when using `decode` although happening further up the call stack. this PR is to remove this encoding check altogether. 