### PR TITLE
Update MessageHubProduceTests to not rely on activation polling

### DIFF
--- a/tests/dat/createTriggerActionsFromKey.js
+++ b/tests/dat/createTriggerActionsFromKey.js
@@ -1,0 +1,11 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
+var openwhisk = require('openwhisk');
+
+function main(params) {
+    console.log(JSON.stringify(params));
+    var name = params.messages[0].key;
+    var ow = openwhisk({ignore_certs: true});
+    return ow.triggers.create({name: name});
+}

--- a/tests/src/test/scala/system/packages/MessageHubMultiWorkersTest.scala
+++ b/tests/src/test/scala/system/packages/MessageHubMultiWorkersTest.scala
@@ -150,7 +150,7 @@ class MessageHubMultiWorkersTest extends FlatSpec
       })
   }
 
-  ignore should "balance the load accross workers when a worker is added" in withAssetCleaner(wskprops) {
+  ignore should "balance the load across workers when a worker is added" in withAssetCleaner(wskprops) {
 
     (wp, assetHelper) =>
       val firstTrigger = s"firstTrigger-${System.currentTimeMillis()}"


### PR DESCRIPTION
Removes activation polling from the MessageHubProduceTests to reduce intermittent failures.