### PR TITLE
Switch to Scala 2.12.7

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,6 @@ gradle.ext.openwhisk = [
 ]
 
 gradle.ext.scala = [
-    version: '2.11.8',
+    version: '2.12.7',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -29,7 +29,7 @@ git clone https://github.com/apache/incubator-openwhisk-utilities.git
 
 # OpenWhisk stuff
 cd $HOMEDIR
-git clone https://github.com/apache/incubator-openwhisk.git openwhisk
+git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
 cd $WHISKDIR
 
 TERM=dumb ./gradlew \

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -29,7 +29,7 @@ git clone https://github.com/apache/incubator-openwhisk-utilities.git
 
 # OpenWhisk stuff
 cd $HOMEDIR
-git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
+git clone https://github.com/apache/incubator-openwhisk.git openwhisk
 cd $WHISKDIR
 
 TERM=dumb ./gradlew \


### PR DESCRIPTION
Switches Scala version to 2.12.7 as part of apache/incubator-openwhisk#3952

To validate that build passes fine this PR build against the [scala-2-12][1] branch. Following sequence of steps would happen

1. apache/incubator-openwhisk#4062 is merged
2. Change the git url in install scripts
3. Merge this PR

[1]: https://github.com/chetanmeh/incubator-openwhisk/tree/scala-2-12