### PR TITLE
Treat malformed JSON as a string

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -477,6 +477,7 @@ class ConsumerProcess (Process):
             except ValueError:
                 # no big deal, just return the original value
                 logging.warn('[{}] I was asked to encode a message as JSON, but I failed.'.format(self.trigger))
+                value = "\"{}\"".format(value)
                 pass
         elif self.encodeValueAsBase64:
             try:


### PR DESCRIPTION
A consumer will crash if JSON is not properly encoded.