### PR TITLE
Remove test for MessageHub invalid auth

### DIFF
--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -110,16 +110,6 @@ class MessageHubProduceTests
         testMissingParameter("value")
     }
 
-    it should "Reject with bad credentials" in {
-        val badAuthParams = validParameters + ("user" -> "ThisWillNeverWork".toJson)
-
-        withActivation(wsk.activation, wsk.action.invoke(s"$messagingPackage/$messageHubProduce", badAuthParams), totalWait = 60 seconds) {
-            activation =>
-                activation.response.success shouldBe false
-                activation.response.result.get.toString should include("Authentication failed")
-        }
-    }
-
     it should "Reject trying to decode a non-base64 key" in {
         val badKeyParams = validParameters + ("key" -> "?".toJson) + ("base64DecodeKey" -> true.toJson)
 


### PR DESCRIPTION
Removes a test entitled `Reject with bad credentials` as this tests MessageHub functionality and does not actually test the MessageHub provider.