### PR TITLE
Use KafkaProducer Instead of messageHubProduce

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -45,10 +45,16 @@ task testHealth(type: Test) {
   include 'system/health/**'
 }
 
-task testNoHealth(type: Test) {
+task testWithProducer(type: Test) {
+  configure commonConfiguration
+  exclude 'system/packages/MessageHubProduceTests.class'
+  exclude 'system/packages/MessagingServiceTests.class'
+  exclude 'system/stress/**'
+}
+
+task testWithProducerAndProducerAction(type: Test) {
   configure commonConfiguration
   exclude 'system/stress/**'
-  exclude 'system/health/**'
   exclude 'system/packages/MessagingServiceTests.class'
 }
 

--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -99,13 +99,7 @@ class BasicHealthTest
         trigger.get(name, NOT_FOUND)
       }
 
-      println(s"Producing message with key: $key and value: $verificationName")
-      val producer = createProducer()
-      val record = new ProducerRecord(topic, key, verificationName)
-      val future = producer.send(record)
-
-      producer.flush()
-      producer.close()
+      produceMessage(topic, key, verificationName)
 
       try {
         val result = future.get(60, TimeUnit.SECONDS)

--- a/tests/src/test/scala/system/utils/KafkaUtils.scala
+++ b/tests/src/test/scala/system/utils/KafkaUtils.scala
@@ -117,6 +117,16 @@ trait KafkaUtils extends TestHelpers with WskTestHelpers {
             assert(uuids.nonEmpty)
         }, N = 60, waitBeforeRetry = Some(1.second))
     }
+
+    def produceMessage(topic: String, key: String, value: String) = {
+        println(s"Producing message with key: $key and value: $value")
+        val producer = createProducer()
+        val record = new ProducerRecord(topic, key, value)
+        val future = producer.send(record)
+
+        producer.flush()
+        producer.close()
+    }
 }
 
 object KafkaUtils {


### PR DESCRIPTION
Decouples the use of `messageHubProduce` from all test suites that are not `MessageHubProduceTests`.