### PR TITLE
alpine image does not contain apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6
 
 # install system deps
 RUN apt-get update


### PR DESCRIPTION
do not use the alpine image of python 3.6 for base image since it does not contain apt-get