### PR TITLE
Do not fire trigger with invalid JSON

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -485,7 +485,7 @@ class ConsumerProcess (Process):
 
         if self.encodeValueAsJSON:
             try:
-                parsed = json.loads(value)
+                parsed = json.loads(value, parse_constant=self.__errorOnJSONConstant)
                 logging.debug('[{}] Successfully encoded a message as JSON.'.format(self.trigger))
                 return parsed
             except ValueError:
@@ -523,3 +523,6 @@ class ConsumerProcess (Process):
 
     def __on_revoke(self, consumer, partitions):
         logging.info('[{}] Partition assignment has been revoked. Disconnected from broker(s)'.format(self.trigger))
+
+    def __errorOnJSONConstant(message):
+    	raise(ValueError('Invalid JSON detected.'))

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -524,5 +524,5 @@ class ConsumerProcess (Process):
     def __on_revoke(self, consumer, partitions):
         logging.info('[{}] Partition assignment has been revoked. Disconnected from broker(s)'.format(self.trigger))
 
-    def __errorOnJSONConstant(message):
+    def __errorOnJSONConstant(self, data):
     	raise(ValueError('Invalid JSON detected.'))


### PR DESCRIPTION
Due to the default behavior of Python's `json.loads()`, invalid JSON can be passed to the OpenWhisk Controller when firing a trigger. This occurs when constants `NaN`, `Infinity`, `-Infinity` are present in the JSON consumed from Kafka. Such an event results in a `400` HTTP error from the trigger invocation request. When a `400` status code is returned to the Kafka provider, the user's corresponding trigger is automatically disabled.

Showing `json.loads` parsing `NaN` without a failure.
```
json.loads('{"a":[NaN,NaN,123]}')
{u'a': [nan, nan, 123]}
```

Providing a `parse_constant` function that throws an error allows us to fail when `NaN` is present.
```
json.loads('{"a":[NaN]}', parse_constant=parseJSONConstant)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 351, in loads
    return cls(encoding=encoding, **kw).decode(s)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 382, in raw_decode
    obj, end = self.scan_once(s, idx)
  File "<stdin>", line 3, in parseJSONConstant
ValueError: Invalid JSON detected
```