### PR TITLE
Add API key annotation to tests that rely on Node.js client

### DIFF
--- a/tests/src/test/scala/system/health/BasicHealthTest.scala
+++ b/tests/src/test/scala/system/health/BasicHealthTest.scala
@@ -26,6 +26,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import system.utils.KafkaUtils
 import org.apache.openwhisk.utils.retry
+import org.apache.openwhisk.core.entity.WhiskAction
 
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
@@ -78,7 +79,7 @@ class BasicHealthTest
       val defaultActionName = s"helloKafka-$currentTime"
 
       assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-        action.create(name, defaultAction)
+        action.create(name, defaultAction, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
 
       assetHelper.withCleaner(wsk.rule, s"dummyMessageHub-helloKafka-$currentTime") { (rule, name) =>

--- a/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubFeedTests.scala
@@ -38,6 +38,7 @@ import common.WskTestHelpers
 import ActionHelper._
 import common.TestUtils.NOT_FOUND
 import org.apache.openwhisk.utils.retry
+import org.apache.openwhisk.core.entity.WhiskAction
 import java.util.concurrent.ExecutionException
 
 @RunWith(classOf[JUnitRunner])
@@ -136,7 +137,7 @@ class MessageHubFeedTests
       val defaultActionName = s"helloKafka-${currentTime}"
 
       assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-        action.create(name, defaultAction)
+        action.create(name, defaultAction, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
         rule.create(name, trigger = triggerName, action = defaultActionName)
@@ -189,7 +190,7 @@ class MessageHubFeedTests
       val defaultActionName = s"helloKafka-${currentTime}"
 
       assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-        action.create(name, defaultAction)
+        action.create(name, defaultAction, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
         rule.create(name, trigger = triggerName, action = defaultActionName)
@@ -365,7 +366,7 @@ class MessageHubFeedTests
       val defaultActionName = s"helloKafka-${currentTime}"
 
       assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-        action.create(name, defaultAction1)
+        action.create(name, defaultAction1, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
         rule.create(name, trigger = triggerName, action = defaultActionName)
@@ -400,7 +401,7 @@ class MessageHubFeedTests
       }
 
       val defaultAction2 = Some("dat/createTriggerActionsFromEncodedMessage.js")
-      wsk.action.create(defaultActionName, defaultAction2, update = true)
+      wsk.action.create(defaultActionName, defaultAction2, update = true, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
 
       println("Giving the consumer a moment to get ready")
       Thread.sleep(consumerInitTime)
@@ -430,7 +431,7 @@ class MessageHubFeedTests
       val defaultActionName = s"helloKafka-${currentTime}"
 
       assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-        action.create(name, defaultAction1)
+        action.create(name, defaultAction1, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
       assetHelper.withCleaner(wsk.rule, "rule") { (rule, name) =>
         rule.create(name, trigger = triggerName, action = defaultActionName)

--- a/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
+++ b/tests/src/test/scala/system/packages/MessageHubProduceTests.scala
@@ -43,6 +43,7 @@ import java.util.Base64
 import java.nio.charset.StandardCharsets
 
 import org.apache.openwhisk.utils.retry
+import org.apache.openwhisk.core.entity.WhiskAction
 
 @RunWith(classOf[JUnitRunner])
 class MessageHubProduceTests
@@ -145,7 +146,7 @@ class MessageHubProduceTests
             val defaultActionName = s"helloKafka-${currentTime}"
 
             assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-                action.create(name, defaultAction)
+                action.create(name, defaultAction, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
             }
 
             assetHelper.withCleaner(wsk.rule, s"dummyMessageHub-helloKafka-$currentTime") { (rule, name) =>
@@ -189,7 +190,7 @@ class MessageHubProduceTests
             val defaultActionName = s"helloKafka-${currentTime}"
 
             assetHelper.withCleaner(wsk.action, defaultActionName) { (action, name) =>
-                action.create(name, defaultAction)
+                action.create(name, defaultAction, annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
             }
 
             assetHelper.withCleaner(wsk.rule, s"dummyMessageHub-helloKafka-$currentTime") { (rule, name) =>


### PR DESCRIPTION
Actions that depend on the Node.js client will require an annotation to allow such actions to access the API key associated with the corresponding namespace. These changes will be introduced by https://github.com/apache/incubator-openwhisk/pull/4284. Since there exists tests in this repo that utilize the Node.js client, those tests will need to create actions with the mentioned annotation.