### PR TITLE
Fix failures related to scan code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,19 @@
-# A Travis CI configuration file.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 sudo: required
 group: deprecated-2017Q3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,22 @@
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 <!--
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-# license agreements.  See the NOTICE file distributed with this work for additional 
-# information regarding copyright ownership.  The ASF licenses this file to you
-# under the Apache License, Version 2.0 (the # "License"); you may not use this 
-# file except in compliance with the License.  You may obtain a copy of the License 
-# at:
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed 
-# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-# CONDITIONS OF ANY KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 -->
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 # Contributing to Apache OpenWhisk
 
@@ -36,18 +37,18 @@ Instructions on how to do this can be found here:
 [http://www.apache.org/licenses/#clas](http://www.apache.org/licenses/#clas)
 
 Once submitted, you will receive a confirmation email from the Apache Software Foundation (ASF) and be added to
-the following list: http://people.apache.org/unlistedclas.html. 
+the following list: http://people.apache.org/unlistedclas.html.
 
 Project committers will use this list to verify pull requests (PRs) come from contributors that have signed a CLA.
 
-We look forward to your contributions! 
+We look forward to your contributions!
 
 ## Raising issues
 
-Please raise any bug reports on the respective project repository's GitHub issue tracker. Be sure to search the 
+Please raise any bug reports on the respective project repository's GitHub issue tracker. Be sure to search the
 list to see if your issue has already been raised.
 
-A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong. 
+A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong.
 Provide as much context as possible so we can try to recreate the issue.
 
 ### Discussion

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # OpenWhisk package for communication with Kafka or IBM Message Hub
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)

--- a/action/kafkaFeed.js
+++ b/action/kafkaFeed.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 const common = require('./lib/common');
 
 /**

--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 const common = require('./lib/common');
 const Database = require('./lib/Database');
 var moment = require('moment');

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 // constructor for DB object - a thin, promise-loving wrapper around nano
 module.exports = function(dbURL, dbName) {
     var nano = require('nano')(dbURL);

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 const request = require('request-promise');
 
 function triggerComponents(triggerName) {

--- a/action/messageHubFeed.js
+++ b/action/messageHubFeed.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 const common = require('./lib/common');
 
 /**

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 const common = require('./lib/common');
 const Database = require('./lib/Database');
 const itm = require('@ibm-functions/iam-token-manager');

--- a/devGuide.md
+++ b/devGuide.md
@@ -1,3 +1,22 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Development and Testing
 ## Build
 Building the Kafka feed provider is a simple matter of running a `docker build` command from the root of the project. I suggest tagging the image with a memorable name, like "kafkafeedprovider":

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,6 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-#
+
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 # use the command line interface to install standard actions deployed
 # automatically
-#
+
 # To run this command
 # ./installCatalog.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost>
 # authkey and apihost are found in $HOME/.wskprops

--- a/installKafka.sh
+++ b/installKafka.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-#
+
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 # use the command line interface to install standard actions deployed
 # automatically
-#
+
 # To run this command
 # ./installKafka.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost>
 # authkey and apihost are found in $HOME/.wskprops

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 set -e
 
 # Build script for Travis-CI.

--- a/tools/travis/deploy.sh
+++ b/tools/travis/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 set -eu
 
 dockerhub_image_prefix="$1"

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"
 WHISKDIR="$HOMEDIR/openwhisk"

--- a/tools/verifyDBMigration/index.js
+++ b/tools/verifyDBMigration/index.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 var shell = require('shelljs');
 
 // will be populated by processArgs()


### PR DESCRIPTION
Scan code is failing due to a different `ASF-Release.cfg` file being used.

Failures:
```
Scanning files starting at [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../..]...
Scan detected 27 error(s) in 17 file(s):
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../.travis.yml]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../CONTRIBUTING.md]:
       1: file does not include required license header.
       4: line has trailing whitespace.
       5: line has trailing whitespace.
       7: line has trailing whitespace.
       8: line has trailing whitespace.
      13: line has trailing whitespace.
      14: line has trailing whitespace.
      39: line has trailing whitespace.
      43: line has trailing whitespace.
      47: line has trailing whitespace.
      50: line has trailing whitespace.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../README.md]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/kafkaFeed.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/kafkaFeedWeb.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/lib/Database.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/lib/common.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/messageHubFeed.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../action/messageHubFeedWeb.js]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../devGuide.md]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../gradle/wrapper/gradle-wrapper.properties]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../installCatalog.sh]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../installKafka.sh]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../tools/travis/build.sh]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../tools/travis/deploy.sh]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../tools/travis/setup.sh]:
       1: file does not include required license header.
  [/home/travis/build/apache/incubator-openwhisk-package-kafka/tools/travis/../../tools/verifyDBMigration/index.js]:
       1: file does not include required license header.
Scan detected 27 error(s) in 17 file(s):

```