### PR TITLE
Prevent parsing floats as Infinity and -Infinity

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -488,9 +488,9 @@ class ConsumerProcess (Process):
                 parsed = json.loads(value, parse_constant=self.__errorOnJSONConstant, parse_float=self.__parseFloat)
                 logging.debug('[{}] Successfully encoded a message as JSON.'.format(self.trigger))
                 return parsed
-            except ValueError:
+            except ValueError as e:
                 # no big deal, just return the original value
-                logging.warn('[{}] I was asked to encode a message as JSON, but I failed.'.format(self.trigger))
+                logging.warn('[{}] I was asked to encode a message as JSON, but I failed with "{}".'.format(self.trigger, e))
                 value = "\"{}\"".format(value)
                 pass
         elif self.encodeValueAsBase64:
@@ -525,7 +525,7 @@ class ConsumerProcess (Process):
         logging.info('[{}] Partition assignment has been revoked. Disconnected from broker(s)'.format(self.trigger))
 
     def __errorOnJSONConstant(self, data):
-    	raise(ValueError('Invalid JSON detected.'))
+    	raise(ValueError('Constant "{}" detected in JSON.'.format(data)))
 
     def __parseFloat(self, data):
         res = float(data)

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -485,7 +485,7 @@ class ConsumerProcess (Process):
 
         if self.encodeValueAsJSON:
             try:
-                parsed = json.loads(value, parse_constant=self.__errorOnJSONConstant)
+                parsed = json.loads(value, parse_constant=self.__errorOnJSONConstant, parse_float=self.__parseFloat)
                 logging.debug('[{}] Successfully encoded a message as JSON.'.format(self.trigger))
                 return parsed
             except ValueError:
@@ -526,3 +526,14 @@ class ConsumerProcess (Process):
 
     def __errorOnJSONConstant(self, data):
     	raise(ValueError('Invalid JSON detected.'))
+
+    def __parseFloat(self, data):
+        res = float(data)
+
+        if res == float('inf'):
+            raise(ValueError('Parsing float value "{}" would result in "Infinity".'.format(data)))
+
+        if res == float('-inf'):
+            raise(ValueError('Parsing float value "{}" would result in "-Infinity".'.format(data)))
+
+        return res


### PR DESCRIPTION
When reading a very large or very small float from Kafka, the consumer may convert that number into `Infinity` or `-Infinity` respectively. These changes cause an exception to occur in the `json.loads` function to prevent `Infinity` or `-Infinity` values as the OpenWhisk controller will reject such JSON as being invalid.