### PR TITLE
Reset consumer restart counter after 24 hours

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -34,6 +34,7 @@ from multiprocessing import Process, Manager
 from urlparse import urlparse
 from authHandler import IAMAuth
 from requests.auth import HTTPBasicAuth
+from datetime import datetime, timedelta
 
 local_dev = os.getenv('LOCAL_DEV', 'False')
 payload_limit = int(os.getenv('PAYLOAD_LIMIT', 900000))
@@ -66,6 +67,7 @@ class Consumer:
 
         self.process = ConsumerProcess(trigger, params, self.sharedDictionary)
         self.__restartCount = 0
+        self.__lastRestart = datetime.now()
 
     def currentState(self):
         return self.sharedDictionary['currentState']
@@ -96,7 +98,13 @@ class Consumer:
             logging.info('[{}] Request to restart a consumer that is already slated for deletion.'.format(self.trigger))
             return
 
-        self.__restartCount += 1
+        timeBetweenRestarts = datetime.now() - self.__lastRestart
+        self.__lastRestart = datetime.now()
+
+        if timeBetweenRestarts.total_seconds() >= timedelta(seconds=24*60*60).total_seconds():
+            self.__restartCount = 1
+        else:
+            self.__restartCount += 1
 
         logging.info('[{}] Quietly shutting down consumer for restart'.format(self.trigger))
         self.setDesiredState(Consumer.State.Restart)

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -39,6 +39,7 @@ from datetime import datetime, timedelta
 local_dev = os.getenv('LOCAL_DEV', 'False')
 payload_limit = int(os.getenv('PAYLOAD_LIMIT', 900000))
 check_ssl = (local_dev == 'False')
+seconds_in_day = 86400
 
 processingManager = Manager()
 
@@ -101,7 +102,7 @@ class Consumer:
         timeBetweenRestarts = datetime.now() - self.__lastRestart
         self.__lastRestart = datetime.now()
 
-        if timeBetweenRestarts.total_seconds() >= timedelta(seconds=24*60*60).total_seconds():
+        if timeBetweenRestarts.total_seconds() >= seconds_in_day:
             self.__restartCount = 1
         else:
             self.__restartCount += 1


### PR DESCRIPTION
Due to a bug in the Kafka client being used, a consumer may restart incrementally over time, resulting in the consumer restart counter continually increasing. A restart counter that gradually increases over time may create false alarms if the value is being used for health monitoring purposes. Given such a scenario, the changes here with reset the restart counter when a consumer restarts after a 24 hour period. 

Related client bug: https://github.com/apache/incubator-openwhisk-package-kafka/blob/master/provider/thedoctor.py#L67.