### PR TITLE
Upgrade librdkafka to latest major release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7.16
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka
-ENV LIBRDKAFKA_VERSION 0.11.6
+ENV LIBRDKAFKA_VERSION 1.0.0
 RUN git clone --depth 1 --branch v${LIBRDKAFKA_VERSION} https://github.com/edenhill/librdkafka.git librdkafka \
     && cd librdkafka \
     && ./configure \


### PR DESCRIPTION
Updating the `librdkafka` package to the first major release, `1.0.0`. The change log for this release can be found here: https://github.com/edenhill/librdkafka/releases/tag/v1.0.0. 

Highlights of this release include:
https://github.com/edenhill/librdkafka/pull/2124
https://github.com/edenhill/librdkafka/pull/2188
https://github.com/edenhill/librdkafka/issues/2138
https://github.com/edenhill/librdkafka/pull/2152
https://github.com/edenhill/librdkafka/pull/2054