### PR TITLE
Set consumer state to running after brokers and partitions are assigned

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -329,7 +329,6 @@ class ConsumerProcess (Process):
 
                 if self.secondsSinceLastPoll() < 0:
                     logging.info('[{}] Completed first poll'.format(self.trigger))
-                    self.__recordState(Consumer.State.Running)
 
                 if (message is not None):
                     if not message.error():
@@ -529,6 +528,10 @@ class ConsumerProcess (Process):
 
     def __on_assign(self, consumer, partitions):
         logging.info('[{}] Completed partition assignment. Connected to broker(s)'.format(self.trigger))
+
+        if self.currentState() == Consumer.State.Initializing and self.__shouldRun():
+            logging.info('[{}] Setting consumer state to runnning.'.format(self.trigger))
+            self.__recordState(Consumer.State.Running)
 
     def __on_revoke(self, consumer, partitions):
         logging.info('[{}] Partition assignment has been revoked. Disconnected from broker(s)'.format(self.trigger))


### PR DESCRIPTION
Currently the provider sets the consumer state to running when polling begins. However, this is not an accurate state as the call to subscribe a consumer is non-blocking. Meaning polling can begin before a consumer is connected to any brokers or assigned partitions, resulting in the consumer being set to a running state even though it is not possible to consumer messages yet. This can be problematic for integration tests that check the consumer health endpoint to see if a consumer is in a proper running state prior to producing test messages. To rectify this problem, the changes here set the consumer state to running only after brokers and partitions are assigned to the consumer.