### PR TITLE
Disable spare connections

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -296,7 +296,8 @@ class ConsumerProcess (Process):
                         'group.id': self.trigger,
                         'default.topic.config': {'auto.offset.reset': 'latest'},
                         'enable.auto.commit': False,
-                        'api.version.request': True
+                        'api.version.request': True,
+                        'enable.sparse.connections': False
                     }
 
             if self.isMessageHub:


### PR DESCRIPTION
There's a bug in version 1.0.0 of librdkafka that can cause a consumer to not recover in a timely manner when a non-group coordinator connection is lost. As a work around, disable the spare connections feature until the fix has been officially released. The spare connection feature is new to version 1.0.0 of the client, so was not being used previously anyway.

More info here: https://github.com/edenhill/librdkafka/issues/2266