### PR TITLE
Catch Doctor exceptions and do not persist consumer database connections

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -179,7 +179,12 @@ class ConsumerProcess (Process):
         else:
             self.encodeKeyAsBase64 = False
 
-        self.database = Database()
+        # when failing to establish a database connection, mark the consumer as dead to restart the consumer
+        try:
+            self.database = Database()
+        except Exception as e:
+            logging.error('[{}] Uncaught exception: {}'.format(self.trigger, e))
+            self.__recordState(Consumer.State.Dead)
 
         # always init consumer to None in case the consumer needs to shut down
         # before the KafkaConsumer is fully initialized/assigned

--- a/provider/thedoctor.py
+++ b/provider/thedoctor.py
@@ -43,32 +43,35 @@ class TheDoctor (Thread):
         logging.info('[Doctor] The Doctor is in!')
 
         while True:
-            consumers = self.consumerCollection.getCopyForRead()
+            try:
+                consumers = self.consumerCollection.getCopyForRead()
 
-            for consumerId in consumers:
-                consumer = consumers[consumerId]
-                logging.debug('[Doctor] [{}] Consumer is in state: {}'.format(consumerId, consumer.currentState()))
+                for consumerId in consumers:
+                    consumer = consumers[consumerId]
+                    logging.debug('[Doctor] [{}] Consumer is in state: {}'.format(consumerId, consumer.currentState()))
 
-                if consumer.currentState() == Consumer.State.Dead and consumer.desiredState() == Consumer.State.Running:
-                    # well this is unexpected...
-                    logging.error('[Doctor][{}] Consumer is dead, but should be alive!'.format(consumerId))
-                    consumer.restart()
-                elif consumer.currentState() == Consumer.State.Dead and consumer.desiredState() == Consumer.State.Dead:
-                    # Bring out yer dead...
-                    if consumer.process.is_alive():
-                        logging.info('[{}] Joining dead process.'.format(consumer.trigger))
-                        # if you don't first join the process, it'll be left hanging around as a "defunct" process
-                        consumer.process.join(1)
-                    else:
-                        logging.info('[{}] Process is already dead.'.format(consumer.trigger))
+                    if consumer.currentState() == Consumer.State.Dead and consumer.desiredState() == Consumer.State.Running:
+                        # well this is unexpected...
+                        logging.error('[Doctor][{}] Consumer is dead, but should be alive!'.format(consumerId))
+                        consumer.restart()
+                    elif consumer.currentState() == Consumer.State.Dead and consumer.desiredState() == Consumer.State.Dead:
+                        # Bring out yer dead...
+                        if consumer.process.is_alive():
+                            logging.info('[{}] Joining dead process.'.format(consumer.trigger))
+                            # if you don't first join the process, it'll be left hanging around as a "defunct" process
+                            consumer.process.join(1)
+                        else:
+                            logging.info('[{}] Process is already dead.'.format(consumer.trigger))
 
-                    logging.info('[{}] Removing dead consumer from the collection.'.format(consumer.trigger))
-                    self.consumerCollection.removeConsumerForTrigger(consumer.trigger)
-                elif consumer.secondsSinceLastPoll() > self.poll_timeout_seconds and consumer.desiredState() == Consumer.State.Running:
-                    # there seems to be an issue with the kafka-python client where it gets into an
-                    # error-handling loop. This causes poll() to never complete, but also does not
-                    # throw an exception.
-                    logging.error('[Doctor][{}] Consumer timed-out, but should be alive! Restarting consumer.'.format(consumerId))
-                    consumer.restart()
+                        logging.info('[{}] Removing dead consumer from the collection.'.format(consumer.trigger))
+                        self.consumerCollection.removeConsumerForTrigger(consumer.trigger)
+                    elif consumer.secondsSinceLastPoll() > self.poll_timeout_seconds and consumer.desiredState() == Consumer.State.Running:
+                        # there seems to be an issue with the kafka-python client where it gets into an
+                        # error-handling loop. This causes poll() to never complete, but also does not
+                        # throw an exception.
+                        logging.error('[Doctor][{}] Consumer timed-out, but should be alive! Restarting consumer.'.format(consumerId))
+                        consumer.restart()
 
-            time.sleep(self.sleepy_time_seconds)
+                time.sleep(self.sleepy_time_seconds)
+            except Exception as e:
+                logging.error("[Doctor] Uncaught exception: {}".format(e))


### PR DESCRIPTION
An exception thrown when the Doctor is restarting a consumer will result in the Doctor completely shutting down due to the exception not being caught. As a result, exceptions in the Doctor's run loop need to be handled properly. 

The exception causing the Doctor to crash occurs when the Doctor restarts a consumer and an attempt to create a database connection fails on consumer init. Since a presistant database connection is not needed by the consumer itself, only create the database connection when it is needed to automatically disable a trigger.

Below is a stacktrace showing the described exception occuring:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/KafkaFeedProvider/thedoctor.py", line 72, in run
    consumer.restart()
  File "/KafkaFeedProvider/consumer.py", line 119, in restart
    self.process = ConsumerProcess(self.trigger, self.params, self.sharedDictionary)
  File "/KafkaFeedProvider/consumer.py", line 182, in __init__
    self.database = Database()
  File "/KafkaFeedProvider/database.py", line 48, in __init__
    self.client.connect()
  File "/usr/local/lib/python2.7/site-packages/cloudant/client.py", line 117, in connect
    self.session_login(self._user, self._auth_token)
  File "/usr/local/lib/python2.7/site-packages/cloudant/client.py", line 173, in session_login
    headers={'Content-Type': 'application/x-www-form-urlencoded'}
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 518, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/cloudant/_common_util.py", line 310, in request
    method, url, timeout=self._timeout, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/adapters.py", line 467, in send
    raise ConnectionError(e, request=request)
ConnectionError: HTTPSConnectionPool(host='OMITTED', port=443): Max retries exceeded with url: /_session (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f84d75789d0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution',))
```